### PR TITLE
log error instead of batches

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -40,12 +40,6 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/0xPolygon/cdk-validium-node v0.0.0-20230828091841-53a4ff42575c h1:/AT9WTGa5TXbmSn5BzTznjZL7WNVKHHO4KhTnCAH0Q8=
-github.com/0xPolygon/cdk-validium-node v0.0.0-20230828091841-53a4ff42575c/go.mod h1:oepsDPkqB4bnRzlho4oCcqf86KMS1LKldtAgfkgI1Lw=
-github.com/0xPolygon/cdk-validium-node v0.0.0-20230830125933-503fef88585d h1:Oq1E0bEuVQOPi4s6geJMGBL6x08nBlh6+y56cR8pdyw=
-github.com/0xPolygon/cdk-validium-node v0.0.0-20230830125933-503fef88585d/go.mod h1:oepsDPkqB4bnRzlho4oCcqf86KMS1LKldtAgfkgI1Lw=
-github.com/0xPolygon/cdk-validium-node v0.0.0-20230830141128-b425892819ee h1:SSe+AG9tEyQJrLlZapJwx7Jmq3bREQdWU4qoSKCySlM=
-github.com/0xPolygon/cdk-validium-node v0.0.0-20230830141128-b425892819ee/go.mod h1:ItzCrVSs2aANhYALEhUYBCt+EHtVqML7nIMItHMDPXA=
 github.com/0xPolygon/cdk-validium-node v0.0.0-20230831094457-8d07bc9043a8 h1:YAE4/B4nufZNzNgytGjO7nmWxkeo8zIk1sNJvLSslC8=
 github.com/0xPolygon/cdk-validium-node v0.0.0-20230831094457-8d07bc9043a8/go.mod h1:fRivadZM1gxM3n00U1jIt/udwYaN/ktap0GRGiwLBug=
 github.com/0xPolygonHermez/zkevm-node v0.1.0-RC8.0.20230601153103-86d9fb808691 h1:PTbLJ6HEQ9J0CzKrv62n/l4GsGYygyAVX4kRAWY530Q=

--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -95,7 +95,7 @@ func (bs *BatchSynchronizer) consumeEvents(
 		case sb := <-events:
 			err := bs.handleSequenceBatches(sb)
 			if err != nil {
-				log.Errorf("failed to process batches: %v", sb)
+				log.Errorf("failed to process batches: %v", err)
 				return true
 			}
 		case r := <-bs.reorgs:


### PR DESCRIPTION
This PR fixes the error logging on the batch synchronizer. The log was not showing the error, only the batch payload. This will help diagnose errors faster.