### PR TITLE
Synchro fix

### DIFF
--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -215,9 +215,7 @@ func (bs *BatchSynchronizer) handleEvent(event *cdkvalidium.CdkvalidiumSequenceB
 
 	var data []offchaindata.OffChainData
 	for _, key := range missing {
-
 		log.Infof("resolving missing key %v", key.Hex())
-
 		var value offchaindata.OffChainData
 		value, err = bs.resolve(key)
 		if err != nil {

--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -252,7 +252,7 @@ func (bs *BatchSynchronizer) resolve(key common.Hash) (offchaindata.OffChainData
 			delete(bs.committee, member.Addr)
 			continue // malformed committee, skip what is known to be wrong
 		}
-		log.Infof("trying dac %s: %s (self: %s)", member.Addr.Hex(), member.URL, bs.self.Hex())
+		log.Infof("trying DAC %s: %s", member.Addr.Hex(), member.URL)
 		value, err := resolveWithMember(key, member)
 		if err != nil {
 			log.Warnf("error resolving, continuing: %v", err)

--- a/synchronizer/rpc.go
+++ b/synchronizer/rpc.go
@@ -19,7 +19,7 @@ func resolveWithMember(key common.Hash, member etherman.DataCommitteeMember) (of
 	ctx, cancel := context.WithTimeout(context.Background(), rpcTimeout)
 	defer cancel()
 
-	log.Debugf("trying member %v for key %v", member.URL, key.Hex())
+	log.Debugf("trying member %v at %v for key %v", member.Addr.Hex(), member.URL, key.Hex())
 
 	bytes, err := cm.GetOffChainData(ctx, key)
 	if len(bytes) == 0 {

--- a/synchronizer/store.go
+++ b/synchronizer/store.go
@@ -67,7 +67,7 @@ func exists(db *db.DB, key common.Hash) bool {
 	return db.Exists(ctx, key)
 }
 
-func store(db *db.DB, block uint64, data []offchaindata.OffChainData) error {
+func store(db *db.DB, data []offchaindata.OffChainData) error {
 	ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
 	defer cancel()
 	var (
@@ -78,10 +78,6 @@ func store(db *db.DB, block uint64, data []offchaindata.OffChainData) error {
 		return err
 	}
 	if err = db.StoreOffChainData(ctx, data, dbTx); err != nil {
-		rollback(ctx, err, dbTx)
-		return err
-	}
-	if err = db.StoreLastProcessedBlock(ctx, block, dbTx); err != nil {
 		rollback(ctx, err, dbTx)
 		return err
 	}

--- a/test/config/test.dev.toml
+++ b/test/config/test.dev.toml
@@ -8,6 +8,7 @@ DataCommitteeAddress = "0xE660928f13F51bEbb553063A1317EDC0e7038949"
 Timeout = "1m"
 RetryPeriod = "5s"
 
+
 [Log]
 Environment = "development" # "production" or "development"
 Level = "debug"

--- a/test/config/test.docker.toml
+++ b/test/config/test.docker.toml
@@ -7,6 +7,7 @@ CDKValidiumAddress = "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
 DataCommitteeAddress = "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6"
 Timeout = "3m"
 RetryPeriod = "5s"
+BlockBatchSize = 32
 
 [Log]
 Environment = "development" # "production" or "development"


### PR DESCRIPTION
This PR fixes case where batch size is not supplied, fixes a bug with storing sync_info, and simplifies the filter workers.

It also introduces a late comer in the DAC test, which turns on after the transactions are mined, and catches up by getting data from other DAC members.

- the test still seems a bit flakey, maybe with timing? 
- the test generates a tx with a key, but no value, but that comes from the cdk-validium-node test operations 