### PR TITLE
Storage optimized sync tracking

### DIFF
--- a/db/migrations/0003.sql
+++ b/db/migrations/0003.sql
@@ -1,0 +1,16 @@
+-- +migrate Down
+DROP TABLE IF EXISTS data_node.sync_tasks CASCADE;
+
+-- +migrate Up
+CREATE TABLE data_node.sync_tasks
+(
+    task        VARCHAR PRIMARY KEY,
+    block       BIGINT NOT NULL,
+    processed   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- transfer data from old table to new
+INSERT INTO data_node.sync_tasks (task, block)
+    SELECT 'L1', MAX(block) FROM data_node.sync_info;
+
+DROP TABLE IF EXISTS data_node.sync_info CASCADE;

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/hermeznetwork/tracerr v0.3.2
 	github.com/invopop/jsonschema v0.7.0
-	github.com/jackc/pgconn v1.14.1
 	github.com/jackc/pgx/v4 v4.18.1
 	github.com/miguelmota/go-solidity-sha3 v0.1.1
 	github.com/mitchellh/mapstructure v1.5.0
@@ -43,6 +42,7 @@ require (
 	github.com/holiman/uint256 v1.2.3 // indirect
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/pgconn v1.14.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.2 // indirect

--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -103,7 +103,7 @@ func (bs *BatchSynchronizer) handleReorgs() {
 				// only reset start block if necessary
 				continue
 			}
-			err = rewindStartBlock(bs.db, r.Number)
+			err = setStartBlock(bs.db, r.Number)
 			if err != nil {
 				log.Errorf("failed to store new start block to %d: %v", r.Number, err)
 			}

--- a/synchronizer/store.go
+++ b/synchronizer/store.go
@@ -13,13 +13,13 @@ import (
 
 const dbTimeout = 2 * time.Second
 
-const L1SyncTask = "L1"
+const l1SyncTask = "L1"
 
 func getStartBlock(db *db.DB) (uint64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
 	defer cancel()
 
-	start, err := db.GetLastProcessedBlock(ctx, L1SyncTask)
+	start, err := db.GetLastProcessedBlock(ctx, l1SyncTask)
 	if err != nil {
 		log.Errorf("error retrieving last processed block, starting from 0: %v", err)
 	}
@@ -39,7 +39,7 @@ func setStartBlock(db *db.DB, block uint64) error {
 	if dbTx, err = db.BeginStateTransaction(ctx); err != nil {
 		return err
 	}
-	err = db.StoreLastProcessedBlock(ctx, L1SyncTask, block, dbTx)
+	err = db.StoreLastProcessedBlock(ctx, l1SyncTask, block, dbTx)
 	if err != nil {
 		return err
 	}

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,8 +14,11 @@ run: stop ## Runs a full node for e2e
 .PHONY: stop
 stop: ## Stop a full data node
 	make stop-dacs
-	make stop-dac-dbs
 	$(STOP)
+
+.PHONY: stop-dacs
+stop-dacs:
+	@./stop-dacs > /dev/null 2>&1
 
 .PHONY: test-e2e
 test-e2e: run ## Runs the E2E tests
@@ -54,19 +57,3 @@ run-network: ## Runs the l1 network
 stop-network: ## Stops the l1 network
 	docker compose stop l1 && docker compose rm -f l1
 
-
-### manual utility to stop dac nodes that were started by e2e, but not stopped by e2e ###
-.PHONY: stop-dac-nodes
-stop-dac-nodes:
-	for i in 0 1 2 3 4 ; do \
-  		(docker kill cdk-data-availability-$$i || true) && (docker rm cdk-data-availability-$$i || true) ; \
-  	done
-
-.PHONY: stop-dac-dbs
-stop-dac-dbs:
-	for i in 0 1 2 3 4 ; do \
-  		(docker kill cdk-validium-data-node-db-$$i || true) && (docker rm cdk-validium-data-node-db-$$i || true); \
-  	done
-
-.PHONY: stop-dacs
-stop-dacs: stop-dac-nodes stop-dac-dbs

--- a/test/stop-dacs
+++ b/test/stop-dacs
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-for i in 0 1 2 3 4 ; do \
-  docker kill cdk-data-availability-$$i || true
-  docker rm cdk-data-availability-$$i || true
-  docker kill cdk-validium-data-node-db-$$i || true
-  docker rm cdk-validium-data-node-db-$$i || true
+for x in cdk-data-availability cdk-validium-data-node-db; do
+  echo $x
+  for i in 0 1 2 3 4; do
+    docker kill $x-$i || true
+    docker rm $x-$i || true
+  done
 done
-

--- a/test/stop-dacs
+++ b/test/stop-dacs
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+for i in 0 1 2 3 4 ; do \
+  docker kill cdk-data-availability-$$i || true
+  docker rm cdk-data-availability-$$i || true
+  docker kill cdk-validium-data-node-db-$$i || true
+  docker rm cdk-validium-data-node-db-$$i || true
+done
+


### PR DESCRIPTION
This PR adds a new table for sync_tasks that stores the last block named tasks have processed, and removes the old sync_info table, which stored a block reference for each block batch processed/scanned. This is better for storage, and will allow other block scanner tasks to use the same pattern and table in the future if required. The SQL is also simplified.  