### PR TITLE
Init L1 sync task

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,12 +85,10 @@ func start(cliCtx *cli.Context) error {
 	selfAddr := crypto.PubkeyToAddress(pk.PublicKey)
 
 	// ensure synchro/reorg start block is set
-	/* TEMPORARY DISABLE TO FIX TEST
 	err = synchronizer.InitStartBlock(storage, c.L1)
 	if err != nil {
 		log.Fatal(err)
 	}
-	*/
 
 	var cancelFuncs []context.CancelFunc
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -84,6 +84,12 @@ func start(cliCtx *cli.Context) error {
 	// derive address
 	selfAddr := crypto.PubkeyToAddress(pk.PublicKey)
 
+	// ensure synchro/reorg start block is set
+	err = synchronizer.InitStartBlock(storage, c.L1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	var cancelFuncs []context.CancelFunc
 
 	sequencerTracker, err := synchronizer.NewSequencerTracker(c.L1, etherman)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,10 +85,12 @@ func start(cliCtx *cli.Context) error {
 	selfAddr := crypto.PubkeyToAddress(pk.PublicKey)
 
 	// ensure synchro/reorg start block is set
+	/* TEMPORARY DISABLE TO FIX TEST
 	err = synchronizer.InitStartBlock(storage, c.L1)
 	if err != nil {
 		log.Fatal(err)
 	}
+	*/
 
 	var cancelFuncs []context.CancelFunc
 

--- a/synchronizer/init.go
+++ b/synchronizer/init.go
@@ -1,0 +1,75 @@
+package synchronizer
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/0xPolygon/cdk-data-availability/config"
+	"github.com/0xPolygon/cdk-data-availability/db"
+	"github.com/0xPolygon/cdk-data-availability/log"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+// InitStartBlock initializes the L1 sync task by finding the inception block for the CDKValidium contract
+func InitStartBlock(db *db.DB, l1 config.L1Config) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	current, err := getStartBlock(db)
+	if err != nil {
+		return err
+	}
+	if current > 0 {
+		// no need to resolve start block, it's already been set
+		return nil
+	}
+	log.Info("starting search for start block of contract", l1.CDKValidiumAddress)
+	startBlock, err := findContractDeploymentBlock(ctx, l1.RpcURL, common.HexToAddress(l1.CDKValidiumAddress))
+	if err != nil {
+		return err
+	}
+	err = setStartBlock(db, startBlock.Uint64())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func findContractDeploymentBlock(ctx context.Context, url string, contract common.Address) (*big.Int, error) {
+	eth, err := ethclient.DialContext(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	latestBlock, err := eth.BlockByNumber(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	b, err := findCode(ctx, eth, contract, 0, latestBlock.Number().Int64())
+	if err != nil {
+		return nil, err
+	}
+	return big.NewInt(b), nil
+}
+
+// findCode is an O(log(n)) search for the inception block of a contract at the given address
+func findCode(ctx context.Context, eth *ethclient.Client, address common.Address, startBlock, endBlock int64) (int64, error) {
+	if startBlock == endBlock {
+		return startBlock, nil
+	}
+	midBlock := (startBlock + endBlock) / 2
+	if codeLen := codeLen(ctx, eth, address, midBlock); codeLen > 2 {
+		return findCode(ctx, eth, address, startBlock, midBlock)
+	} else {
+		return findCode(ctx, eth, address, midBlock+1, endBlock)
+	}
+}
+
+func codeLen(ctx context.Context, eth *ethclient.Client, address common.Address, blockNumber int64) int64 {
+	data, err := eth.CodeAt(ctx, address, big.NewInt(blockNumber))
+	if err != nil {
+		return 0
+	}
+	return int64(len(data))
+}

--- a/synchronizer/init.go
+++ b/synchronizer/init.go
@@ -12,9 +12,14 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
+const (
+	initBlockTimeout = 15 * time.Second
+	minCodeLen       = 2
+)
+
 // InitStartBlock initializes the L1 sync task by finding the inception block for the CDKValidium contract
 func InitStartBlock(db *db.DB, l1 config.L1Config) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), initBlockTimeout)
 	defer cancel()
 
 	current, err := getStartBlock(db)
@@ -58,8 +63,8 @@ func findCode(ctx context.Context, eth *ethclient.Client, address common.Address
 	if startBlock == endBlock {
 		return startBlock, nil
 	}
-	midBlock := (startBlock + endBlock) / 2
-	if codeLen := codeLen(ctx, eth, address, midBlock); codeLen > 2 {
+	midBlock := (startBlock + endBlock) / 2 //nolint:gomnd
+	if codeLen := codeLen(ctx, eth, address, midBlock); codeLen > minCodeLen {
 		return findCode(ctx, eth, address, startBlock, midBlock)
 	} else {
 		return findCode(ctx, eth, address, midBlock+1, endBlock)

--- a/synchronizer/init.go
+++ b/synchronizer/init.go
@@ -51,17 +51,14 @@ func findContractDeploymentBlock(ctx context.Context, url string, contract commo
 	if err != nil {
 		return nil, err
 	}
-	b, err := findCode(ctx, eth, contract, 0, latestBlock.Number().Int64())
-	if err != nil {
-		return nil, err
-	}
-	return big.NewInt(b), nil
+	firstBlock := findCode(ctx, eth, contract, 0, latestBlock.Number().Int64())
+	return big.NewInt(firstBlock), nil
 }
 
 // findCode is an O(log(n)) search for the inception block of a contract at the given address
-func findCode(ctx context.Context, eth *ethclient.Client, address common.Address, startBlock, endBlock int64) (int64, error) {
+func findCode(ctx context.Context, eth *ethclient.Client, address common.Address, startBlock, endBlock int64) int64 {
 	if startBlock == endBlock {
-		return startBlock, nil
+		return startBlock
 	}
 	midBlock := (startBlock + endBlock) / 2 //nolint:gomnd
 	if codeLen := codeLen(ctx, eth, address, midBlock); codeLen > minCodeLen {

--- a/synchronizer/init.go
+++ b/synchronizer/init.go
@@ -30,7 +30,7 @@ func InitStartBlock(db *db.DB, l1 config.L1Config) error {
 		// no need to resolve start block, it's already been set
 		return nil
 	}
-	log.Info("starting search for start block of contract", l1.CDKValidiumAddress)
+	log.Info("starting search for start block of contract ", l1.CDKValidiumAddress)
 	startBlock, err := findContractDeploymentBlock(ctx, l1.RpcURL, common.HexToAddress(l1.CDKValidiumAddress))
 	if err != nil {
 		return err

--- a/test/Makefile
+++ b/test/Makefile
@@ -57,3 +57,12 @@ run-network: ## Runs the l1 network
 stop-network: ## Stops the l1 network
 	docker compose stop l1 && docker compose rm -f l1
 
+.PHONY: run-local
+run-local: run-network ## Run network and db for local instance
+	docker compose up -d cdk-data-availability-db
+
+.PHONY: stop-local
+stop-local: stop-network ## Run network and db for local instance
+	docker compose stop cdk-data-availability-db && docker compose rm -f cdk-data-availability-db
+
+

--- a/test/e2e/datacommittee_test.go
+++ b/test/e2e/datacommittee_test.go
@@ -260,6 +260,7 @@ func startDACMember(t *testing.T, m member) {
 	dacNodeConfig := config.Config{
 		L1: config.L1Config{
 			WsURL:                "ws://l1:8546",
+			RpcURL:               "http://l1:8545",
 			CDKValidiumAddress:   operations.DefaultL1CDKValidiumSmartContract,
 			DataCommitteeAddress: operations.DefaultL1DataCommitteeContract,
 			Timeout:              cTypes.Duration{Duration: time.Second},


### PR DESCRIPTION
This PR adds an initialization step that finds the inception block of the CDKValidium contract and sets the start block for the L1 sync task. It skips the search if the start block is already set. 