### PR TITLE
Introduce `release` github workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      # run only against tags that follow semver (https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string)
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+     
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,113 @@
+# .goreleaser.yaml
+project_name: cdk-data-availability
+
+release:
+  disable: false
+  draft: true
+  prerelease: auto
+
+builds:
+  - id: linux-amd64
+    main: ./cmd/
+    binary: cdk-data-availability
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/0xPolygon/cdk-data-availability.Version={{ .Version }}
+      - -X github.com/0xPolygon/cdk-data-availability.GitRev={{ .Commit }}
+      - -X github.com/0xPolygon/cdk-data-availability.BuildDate={{ .Date }}
+      - -X github.com/0xPolygon/cdk-data-availability.GitBranch={{ .Branch }}
+
+  - id: linux-arm64
+    main: ./cmd/
+    binary: cdk-data-availability
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/0xPolygon/cdk-data-availability.Version={{ .Version }}
+      - -X github.com/0xPolygon/cdk-data-availability.GitRev={{ .Commit }}
+      - -X github.com/0xPolygon/cdk-data-availability.BuildDate={{ .Date }}
+      - -X github.com/0xPolygon/cdk-data-availability.GitBranch={{ .Branch }}
+
+  - main: ./cmd/
+    binary: cdk-data-availability
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/0xPolygon/cdk-data-availability.Version={{ .Version }}
+      - -X github.com/0xPolygon/cdk-data-availability.GitRev={{ .Commit }}
+      - -X github.com/0xPolygon/cdk-data-availability.BuildDate={{ .Date }}
+      - -X github.com/0xPolygon/cdk-data-availability.GitBranch={{ .Branch }}
+
+archives:
+  - files:
+      - LICENSE
+      - README.md
+
+dockers:
+  - image_templates:
+      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
+    dockerfile: Dockerfile.release
+    use: buildx
+    goos: linux
+    goarch: amd64
+    ids:
+      - linux-amd64
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.url=https://github.com/{{ .ProjectName }}
+      - --label=org.opencontainers.image.source=https://github.com/{{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    skip_push: false
+
+  - image_templates:
+      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
+    dockerfile: Dockerfile.release
+    use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+      - linux-arm64
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.url=https://github.com/{{ .ProjectName }}
+      - --label=org.opencontainers.image.source=https://github.com/{{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    skip_push: false
+
+docker_manifests:
+  - name_template: 0xpolygon/{{ .ProjectName }}:{{ .Version }}
+    image_templates:
+      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
+      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
+    skip_push: false
+
+  - name_template: 0xpolygon/{{ .ProjectName }}:latest
+    image_templates:
+      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
+      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
+    skip_push: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,8 +36,6 @@ dockers:
     use: buildx
     goos: linux
     goarch: amd64
-    ids:
-      - linux-amd64
     build_flag_templates:
       - --platform=linux/amd64
       - --label=org.opencontainers.image.title={{ .ProjectName }}
@@ -55,8 +53,6 @@ dockers:
     use: buildx
     goos: linux
     goarch: arm64
-    ids:
-      - linux-arm64
     build_flag_templates:
       - --platform=linux/arm64
       - --label=org.opencontainers.image.title={{ .ProjectName }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,41 +7,10 @@ release:
   prerelease: auto
 
 builds:
-  - id: linux-amd64
-    main: ./cmd/
-    binary: cdk-data-availability
-    goos:
-      - linux
-    goarch:
-      - amd64
-    env:
-      - CGO_ENABLED=0
-    ldflags:
-      - -s -w
-      - -X github.com/0xPolygon/cdk-data-availability.Version={{ .Version }}
-      - -X github.com/0xPolygon/cdk-data-availability.GitRev={{ .Commit }}
-      - -X github.com/0xPolygon/cdk-data-availability.BuildDate={{ .Date }}
-      - -X github.com/0xPolygon/cdk-data-availability.GitBranch={{ .Branch }}
-
-  - id: linux-arm64
-    main: ./cmd/
-    binary: cdk-data-availability
-    goos:
-      - linux
-    goarch:
-      - arm64
-    env:
-      - CGO_ENABLED=0
-    ldflags:
-      - -s -w
-      - -X github.com/0xPolygon/cdk-data-availability.Version={{ .Version }}
-      - -X github.com/0xPolygon/cdk-data-availability.GitRev={{ .Commit }}
-      - -X github.com/0xPolygon/cdk-data-availability.BuildDate={{ .Date }}
-      - -X github.com/0xPolygon/cdk-data-availability.GitBranch={{ .Branch }}
-
   - main: ./cmd/
     binary: cdk-data-availability
     goos:
+      - linux
       - darwin
     goarch:
       - amd64

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -4,4 +4,9 @@ EXPOSE 8444
 
 COPY cdk-data-availability /usr/local/bin
 
+RUN addgroup -S cdk-dac-group \
+    && adduser -S cdk-dac-user -G cdk-dac-group
+
+USER cdk-dac-user
+
 ENTRYPOINT ["cdk-data-availability"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,7 @@
+FROM alpine:3.16.0
+
+EXPOSE 8444
+
+COPY cdk-data-availability /usr/local/bin
+
+ENTRYPOINT ["cdk-data-availability"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Polygon zkEVM Mainnet Beta 
+CDK Data Availability Layer 
 Copyright (C) 2023 Catenable AG 
 
   This program is free software: you can redistribute it and/or modify it


### PR DESCRIPTION
The PR introduces goreleaser for building and publishing releases for CDK DAC repo. It builds binaries for the predefined platforms and builds and pushes Docker images to the Docker Hub (https://hub.docker.com/r/0xpolygon/cdk-data-availability).