### PR TITLE
DAC batch resolver resilience improvement

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -12,6 +12,322 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_DB_StoreLastProcessedBlock(t *testing.T) {
+	testTable := []struct {
+		name      string
+		task      string
+		block     uint64
+		returnErr error
+	}{
+		{
+			name:  "value inserted",
+			task:  "task1",
+			block: 1,
+		},
+		{
+			name:      "error returned",
+			task:      "task1",
+			block:     1,
+			returnErr: errors.New("test error"),
+		},
+	}
+
+	for _, tt := range testTable {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+
+			defer db.Close()
+
+			expected := mock.ExpectExec(`INSERT INTO data_node\.sync_tasks \(task, block\) VALUES \(\$1, \$2\) ON CONFLICT \(task\) DO UPDATE SET block = EXCLUDED\.block, processed = NOW\(\)`).
+				WithArgs(tt.task, tt.block)
+			if tt.returnErr != nil {
+				expected.WillReturnError(tt.returnErr)
+			} else {
+				expected.WillReturnResult(sqlmock.NewResult(1, 1))
+			}
+
+			wdb := sqlx.NewDb(db, "postgres")
+
+			dbPG := New(wdb)
+
+			err = dbPG.StoreLastProcessedBlock(context.Background(), tt.task, tt.block, wdb)
+			if tt.returnErr != nil {
+				require.ErrorIs(t, err, tt.returnErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func Test_DB_GetLastProcessedBlock(t *testing.T) {
+	testTable := []struct {
+		name      string
+		task      string
+		block     uint64
+		returnErr error
+	}{
+		{
+			name:  "successfully selected block",
+			task:  "task1",
+			block: 1,
+		},
+		{
+			name:      "error returned",
+			task:      "task1",
+			block:     1,
+			returnErr: errors.New("test error"),
+		},
+	}
+
+	for _, tt := range testTable {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+
+			defer db.Close()
+
+			mock.ExpectExec(`INSERT INTO data_node\.sync_tasks \(task, block\) VALUES \(\$1, \$2\) ON CONFLICT \(task\) DO UPDATE SET block = EXCLUDED\.block, processed = NOW\(\)`).
+				WithArgs(tt.task, tt.block).
+				WillReturnResult(sqlmock.NewResult(1, 1))
+
+			expected := mock.ExpectQuery(`SELECT block FROM data_node\.sync_tasks WHERE task = \$1`).
+				WithArgs(tt.task)
+
+			if tt.returnErr != nil {
+				expected.WillReturnError(tt.returnErr)
+			} else {
+				expected.WillReturnRows(sqlmock.NewRows([]string{"block"}).AddRow(tt.block))
+			}
+
+			wdb := sqlx.NewDb(db, "postgres")
+
+			dbPG := New(wdb)
+
+			err = dbPG.StoreLastProcessedBlock(context.Background(), tt.task, tt.block, wdb)
+			require.NoError(t, err)
+
+			actual, err := dbPG.GetLastProcessedBlock(context.Background(), tt.task)
+			if tt.returnErr != nil {
+				require.ErrorIs(t, err, tt.returnErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.block, actual)
+			}
+
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func Test_DB_StoreUnresolvedBatchKeys(t *testing.T) {
+	testTable := []struct {
+		name      string
+		bk        []types.BatchKey
+		returnErr error
+	}{
+		{
+			name: "no values inserted",
+		},
+		{
+			name: "one value inserted",
+			bk: []types.BatchKey{{
+				Number: 1,
+				Hash:   common.HexToHash("key1"),
+			}},
+		},
+		{
+			name: "several values inserted",
+			bk: []types.BatchKey{{
+				Number: 1,
+				Hash:   common.HexToHash("key1"),
+			}, {
+				Number: 2,
+				Hash:   common.HexToHash("key2"),
+			}},
+		},
+		{
+			name: "error returned",
+			bk: []types.BatchKey{{
+				Number: 1,
+				Hash:   common.HexToHash("key1"),
+			}},
+			returnErr: errors.New("test error"),
+		},
+	}
+
+	for _, tt := range testTable {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+
+			defer db.Close()
+
+			for _, o := range tt.bk {
+				expected := mock.ExpectExec(`INSERT INTO data_node\.unresolved_batches \(num, hash\) VALUES \(\$1, \$2\) ON CONFLICT \(num, hash\) DO NOTHING`).
+					WithArgs(o.Number, o.Hash.Hex())
+				if tt.returnErr != nil {
+					expected.WillReturnError(tt.returnErr)
+				} else {
+					expected.WillReturnResult(sqlmock.NewResult(int64(len(tt.bk)), int64(len(tt.bk))))
+				}
+			}
+
+			wdb := sqlx.NewDb(db, "postgres")
+
+			dbPG := New(wdb)
+
+			err = dbPG.StoreUnresolvedBatchKeys(context.Background(), tt.bk, wdb)
+			if tt.returnErr != nil {
+				require.ErrorIs(t, err, tt.returnErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func Test_DB_GetUnresolvedBatchKeys(t *testing.T) {
+	testTable := []struct {
+		name      string
+		bks       []types.BatchKey
+		returnErr error
+	}{
+		{
+			name: "successfully selected data",
+			bks: []types.BatchKey{{
+				Number: 1,
+				Hash:   common.HexToHash("key1"),
+			}},
+		},
+		{
+			name: "error returned",
+			bks: []types.BatchKey{{
+				Number: 1,
+				Hash:   common.HexToHash("key1"),
+			}},
+			returnErr: errors.New("test error"),
+		},
+	}
+
+	for _, tt := range testTable {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+
+			defer db.Close()
+
+			wdb := sqlx.NewDb(db, "postgres")
+
+			// Seed data
+			seedUnresolvedBatchKeys(t, wdb, mock, tt.bks)
+
+			expected := mock.ExpectQuery(`SELECT num, hash FROM data_node\.unresolved_batches`)
+
+			if tt.returnErr != nil {
+				expected.WillReturnError(tt.returnErr)
+			} else {
+				for _, bk := range tt.bks {
+					expected.WillReturnRows(sqlmock.NewRows([]string{"num", "hash"}).AddRow(bk.Number, bk.Hash.Hex()))
+				}
+			}
+
+			dbPG := New(wdb)
+
+			data, err := dbPG.GetUnresolvedBatchKeys(context.Background())
+			if tt.returnErr != nil {
+				require.ErrorIs(t, err, tt.returnErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.bks, data)
+			}
+
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func Test_DB_DeleteUnresolvedBatchKeys(t *testing.T) {
+	testTable := []struct {
+		name      string
+		bks       []types.BatchKey
+		returnErr error
+	}{
+		{
+			name: "value deleted",
+			bks: []types.BatchKey{{
+				Number: 1,
+				Hash:   common.HexToHash("key1"),
+			}},
+		},
+		{
+			name: "error returned",
+			bks: []types.BatchKey{{
+				Number: 1,
+				Hash:   common.HexToHash("key1"),
+			}},
+			returnErr: errors.New("test error"),
+		},
+	}
+
+	for _, tt := range testTable {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+
+			defer db.Close()
+
+			for _, bk := range tt.bks {
+				expected := mock.ExpectExec(`DELETE FROM data_node\.unresolved_batches WHERE num = \$1 AND hash = \$2`).
+					WithArgs(bk.Number, bk.Hash.Hex())
+				if tt.returnErr != nil {
+					expected.WillReturnError(tt.returnErr)
+				} else {
+					expected.WillReturnResult(sqlmock.NewResult(int64(len(tt.bks)), int64(len(tt.bks))))
+				}
+			}
+
+			wdb := sqlx.NewDb(db, "postgres")
+
+			dbPG := New(wdb)
+
+			err = dbPG.DeleteUnresolvedBatchKeys(context.Background(), tt.bks, wdb)
+			if tt.returnErr != nil {
+				require.ErrorIs(t, err, tt.returnErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
 func Test_DB_StoreOffChainData(t *testing.T) {
 	testTable := []struct {
 		name      string
@@ -241,125 +557,6 @@ func Test_DB_Exist(t *testing.T) {
 	}
 }
 
-func Test_DB_StoreLastProcessedBlock(t *testing.T) {
-	testTable := []struct {
-		name      string
-		task      string
-		block     uint64
-		returnErr error
-	}{
-		{
-			name:  "value inserted",
-			task:  "task1",
-			block: 1,
-		},
-		{
-			name:      "error returned",
-			task:      "task1",
-			block:     1,
-			returnErr: errors.New("test error"),
-		},
-	}
-
-	for _, tt := range testTable {
-		tt := tt
-
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			db, mock, err := sqlmock.New()
-			require.NoError(t, err)
-
-			defer db.Close()
-
-			expected := mock.ExpectExec(`INSERT INTO data_node\.sync_tasks \(task, block\) VALUES \(\$1, \$2\) ON CONFLICT \(task\) DO UPDATE SET block = EXCLUDED\.block, processed = NOW\(\)`).
-				WithArgs(tt.task, tt.block)
-			if tt.returnErr != nil {
-				expected.WillReturnError(tt.returnErr)
-			} else {
-				expected.WillReturnResult(sqlmock.NewResult(1, 1))
-			}
-
-			wdb := sqlx.NewDb(db, "postgres")
-
-			dbPG := New(wdb)
-
-			err = dbPG.StoreLastProcessedBlock(context.Background(), tt.task, tt.block, wdb)
-			if tt.returnErr != nil {
-				require.ErrorIs(t, err, tt.returnErr)
-			} else {
-				require.NoError(t, err)
-			}
-
-			require.NoError(t, mock.ExpectationsWereMet())
-		})
-	}
-}
-
-func Test_DB_GetLastProcessedBlock(t *testing.T) {
-	testTable := []struct {
-		name      string
-		task      string
-		block     uint64
-		returnErr error
-	}{
-		{
-			name:  "successfully selected block",
-			task:  "task1",
-			block: 1,
-		},
-		{
-			name:      "error returned",
-			task:      "task1",
-			block:     1,
-			returnErr: errors.New("test error"),
-		},
-	}
-
-	for _, tt := range testTable {
-		tt := tt
-
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			db, mock, err := sqlmock.New()
-			require.NoError(t, err)
-
-			defer db.Close()
-
-			mock.ExpectExec(`INSERT INTO data_node\.sync_tasks \(task, block\) VALUES \(\$1, \$2\) ON CONFLICT \(task\) DO UPDATE SET block = EXCLUDED\.block, processed = NOW\(\)`).
-				WithArgs(tt.task, tt.block).
-				WillReturnResult(sqlmock.NewResult(1, 1))
-
-			expected := mock.ExpectQuery(`SELECT block FROM data_node\.sync_tasks WHERE task = \$1`).
-				WithArgs(tt.task)
-
-			if tt.returnErr != nil {
-				expected.WillReturnError(tt.returnErr)
-			} else {
-				expected.WillReturnRows(sqlmock.NewRows([]string{"block"}).AddRow(tt.block))
-			}
-
-			wdb := sqlx.NewDb(db, "postgres")
-
-			dbPG := New(wdb)
-
-			err = dbPG.StoreLastProcessedBlock(context.Background(), tt.task, tt.block, wdb)
-			require.NoError(t, err)
-
-			actual, err := dbPG.GetLastProcessedBlock(context.Background(), tt.task)
-			if tt.returnErr != nil {
-				require.ErrorIs(t, err, tt.returnErr)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.block, actual)
-			}
-
-			require.NoError(t, mock.ExpectationsWereMet())
-		})
-	}
-}
-
 func seedOffchainData(t *testing.T, db *sqlx.DB, mock sqlmock.Sqlmock, od []types.OffChainData) {
 	t.Helper()
 
@@ -375,6 +572,27 @@ func seedOffchainData(t *testing.T, db *sqlx.DB, mock sqlmock.Sqlmock, od []type
 	require.NoError(t, err)
 
 	err = New(db).StoreOffChainData(context.Background(), od, tx)
+	require.NoError(t, err)
+
+	err = tx.Commit()
+	require.NoError(t, err)
+}
+
+func seedUnresolvedBatchKeys(t *testing.T, db *sqlx.DB, mock sqlmock.Sqlmock, bk []types.BatchKey) {
+	t.Helper()
+
+	mock.ExpectBegin()
+	for i, o := range bk {
+		mock.ExpectExec(`INSERT INTO data_node\.unresolved_batches \(num, hash\) VALUES \(\$1, \$2\) ON CONFLICT \(num, hash\) DO NOTHING`).
+			WithArgs(o.Number, o.Hash.Hex()).
+			WillReturnResult(sqlmock.NewResult(int64(i+1), int64(i+1)))
+	}
+	mock.ExpectCommit()
+
+	tx, err := db.BeginTxx(context.Background(), nil)
+	require.NoError(t, err)
+
+	err = New(db).StoreUnresolvedBatchKeys(context.Background(), bk, tx)
 	require.NoError(t, err)
 
 	err = tx.Commit()

--- a/db/migrations/0004.sql
+++ b/db/migrations/0004.sql
@@ -5,7 +5,7 @@ DROP TABLE IF EXISTS data_node.unresolved_batches CASCADE;
 CREATE TABLE data_node.unresolved_batches
 (
     num         BIGINT NOT NULL,
-    hash        VARCHAR NOT NULL,
+    hash        VARCHAR(255) NOT NULL,
     created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
 
     PRIMARY KEY (num, hash)

--- a/db/migrations/0004.sql
+++ b/db/migrations/0004.sql
@@ -1,0 +1,12 @@
+-- +migrate Down
+DROP TABLE IF EXISTS data_node.unresolved_batches CASCADE;
+
+-- +migrate Up
+CREATE TABLE data_node.unresolved_batches
+(
+    num         BIGINT NOT NULL,
+    hash        VARCHAR NOT NULL,
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (num, hash)
+);

--- a/mocks/db.generated.go
+++ b/mocks/db.generated.go
@@ -87,6 +87,54 @@ func (_c *DB_BeginStateTransaction_Call) RunAndReturn(run func(context.Context) 
 	return _c
 }
 
+// DeleteUnresolvedBatchKeys provides a mock function with given fields: ctx, bks, dbTx
+func (_m *DB) DeleteUnresolvedBatchKeys(ctx context.Context, bks []types.BatchKey, dbTx sqlx.ExecerContext) error {
+	ret := _m.Called(ctx, bks, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteUnresolvedBatchKeys")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, []types.BatchKey, sqlx.ExecerContext) error); ok {
+		r0 = rf(ctx, bks, dbTx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DB_DeleteUnresolvedBatchKeys_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteUnresolvedBatchKeys'
+type DB_DeleteUnresolvedBatchKeys_Call struct {
+	*mock.Call
+}
+
+// DeleteUnresolvedBatchKeys is a helper method to define mock.On call
+//   - ctx context.Context
+//   - bks []types.BatchKey
+//   - dbTx sqlx.ExecerContext
+func (_e *DB_Expecter) DeleteUnresolvedBatchKeys(ctx interface{}, bks interface{}, dbTx interface{}) *DB_DeleteUnresolvedBatchKeys_Call {
+	return &DB_DeleteUnresolvedBatchKeys_Call{Call: _e.mock.On("DeleteUnresolvedBatchKeys", ctx, bks, dbTx)}
+}
+
+func (_c *DB_DeleteUnresolvedBatchKeys_Call) Run(run func(ctx context.Context, bks []types.BatchKey, dbTx sqlx.ExecerContext)) *DB_DeleteUnresolvedBatchKeys_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]types.BatchKey), args[2].(sqlx.ExecerContext))
+	})
+	return _c
+}
+
+func (_c *DB_DeleteUnresolvedBatchKeys_Call) Return(_a0 error) *DB_DeleteUnresolvedBatchKeys_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *DB_DeleteUnresolvedBatchKeys_Call) RunAndReturn(run func(context.Context, []types.BatchKey, sqlx.ExecerContext) error) *DB_DeleteUnresolvedBatchKeys_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Exists provides a mock function with given fields: ctx, key
 func (_m *DB) Exists(ctx context.Context, key common.Hash) bool {
 	ret := _m.Called(ctx, key)
@@ -251,6 +299,64 @@ func (_c *DB_GetOffChainData_Call) RunAndReturn(run func(context.Context, common
 	return _c
 }
 
+// GetUnresolvedBatchKeys provides a mock function with given fields: ctx
+func (_m *DB) GetUnresolvedBatchKeys(ctx context.Context) ([]types.BatchKey, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUnresolvedBatchKeys")
+	}
+
+	var r0 []types.BatchKey
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) ([]types.BatchKey, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) []types.BatchKey); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]types.BatchKey)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DB_GetUnresolvedBatchKeys_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUnresolvedBatchKeys'
+type DB_GetUnresolvedBatchKeys_Call struct {
+	*mock.Call
+}
+
+// GetUnresolvedBatchKeys is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *DB_Expecter) GetUnresolvedBatchKeys(ctx interface{}) *DB_GetUnresolvedBatchKeys_Call {
+	return &DB_GetUnresolvedBatchKeys_Call{Call: _e.mock.On("GetUnresolvedBatchKeys", ctx)}
+}
+
+func (_c *DB_GetUnresolvedBatchKeys_Call) Run(run func(ctx context.Context)) *DB_GetUnresolvedBatchKeys_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *DB_GetUnresolvedBatchKeys_Call) Return(_a0 []types.BatchKey, _a1 error) *DB_GetUnresolvedBatchKeys_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *DB_GetUnresolvedBatchKeys_Call) RunAndReturn(run func(context.Context) ([]types.BatchKey, error)) *DB_GetUnresolvedBatchKeys_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // StoreLastProcessedBlock provides a mock function with given fields: ctx, task, block, dbTx
 func (_m *DB) StoreLastProcessedBlock(ctx context.Context, task string, block uint64, dbTx sqlx.ExecerContext) error {
 	ret := _m.Called(ctx, task, block, dbTx)
@@ -344,6 +450,54 @@ func (_c *DB_StoreOffChainData_Call) Return(_a0 error) *DB_StoreOffChainData_Cal
 }
 
 func (_c *DB_StoreOffChainData_Call) RunAndReturn(run func(context.Context, []types.OffChainData, sqlx.ExecerContext) error) *DB_StoreOffChainData_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// StoreUnresolvedBatchKeys provides a mock function with given fields: ctx, bks, dbTx
+func (_m *DB) StoreUnresolvedBatchKeys(ctx context.Context, bks []types.BatchKey, dbTx sqlx.ExecerContext) error {
+	ret := _m.Called(ctx, bks, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for StoreUnresolvedBatchKeys")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, []types.BatchKey, sqlx.ExecerContext) error); ok {
+		r0 = rf(ctx, bks, dbTx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DB_StoreUnresolvedBatchKeys_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StoreUnresolvedBatchKeys'
+type DB_StoreUnresolvedBatchKeys_Call struct {
+	*mock.Call
+}
+
+// StoreUnresolvedBatchKeys is a helper method to define mock.On call
+//   - ctx context.Context
+//   - bks []types.BatchKey
+//   - dbTx sqlx.ExecerContext
+func (_e *DB_Expecter) StoreUnresolvedBatchKeys(ctx interface{}, bks interface{}, dbTx interface{}) *DB_StoreUnresolvedBatchKeys_Call {
+	return &DB_StoreUnresolvedBatchKeys_Call{Call: _e.mock.On("StoreUnresolvedBatchKeys", ctx, bks, dbTx)}
+}
+
+func (_c *DB_StoreUnresolvedBatchKeys_Call) Run(run func(ctx context.Context, bks []types.BatchKey, dbTx sqlx.ExecerContext)) *DB_StoreUnresolvedBatchKeys_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]types.BatchKey), args[2].(sqlx.ExecerContext))
+	})
+	return _c
+}
+
+func (_c *DB_StoreUnresolvedBatchKeys_Call) Return(_a0 error) *DB_StoreUnresolvedBatchKeys_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *DB_StoreUnresolvedBatchKeys_Call) RunAndReturn(run func(context.Context, []types.BatchKey, sqlx.ExecerContext) error) *DB_StoreUnresolvedBatchKeys_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -253,50 +253,32 @@ func (bs *BatchSynchronizer) handleUnresolvedBatches() {
 			}
 
 			// Resolve the unresolved data
-			// Pick out any batches that are missing from storage
-			var existing []types.BatchKey
-			var unresolved []types.BatchKey
-			for _, key := range batchKeys {
-				if exists(bs.db, key.Hash) {
-					existing = append(existing, key)
-				} else {
-					unresolved = append(unresolved, key)
-				}
-			}
-
-			// Delete existing keys from unresolved batches
-			if len(existing) > 0 {
-				if err = deleteUnresolvedBatchKeys(bs.db, existing); err != nil {
-					log.Errorf("failed to delete unresolved batch keys: %v", err)
-				}
-			}
-
-			// Break the process if there are no unresolved batches
-			if len(unresolved) == 0 {
-				continue
-			}
-
-			// Resolve the missing data
 			var data []types.OffChainData
 			var resolved []types.BatchKey
-			for _, key := range unresolved {
-				var value *types.OffChainData
-				if value, err = bs.resolve(key); err != nil {
-					log.Errorf("failed to resolve batch %s: %v", key.Hash.Hex(), err)
+			for _, key := range batchKeys {
+				if exists(bs.db, key.Hash) {
+					resolved = append(resolved, key)
+				} else {
+					var value *types.OffChainData
+					if value, err = bs.resolve(key); err != nil {
+						log.Errorf("failed to resolve batch %s: %v", key.Hash.Hex(), err)
+						continue
+					}
+
+					resolved = append(resolved, key)
+					data = append(data, *value)
+				}
+			}
+
+			// Store data of the batches to the DB
+			if len(data) > 0 {
+				if err = storeOffchainData(bs.db, data); err != nil {
+					log.Errorf("failed to store offchain data: %v", err)
 					continue
 				}
-
-				resolved = append(resolved, key)
-				data = append(data, *value)
 			}
 
-			// Finally, store the data
-			if err = storeOffchainData(bs.db, data); err != nil {
-				log.Errorf("failed to store offchain data: %v", err)
-				continue
-			}
-
-			// Delete keys from unresolved batches
+			// Mark batches as resolved
 			if len(resolved) > 0 {
 				if err = deleteUnresolvedBatchKeys(bs.db, resolved); err != nil {
 					log.Errorf("failed to delete successfully resolved batch keys: %v", err)

--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -96,7 +96,7 @@ func (bs *BatchSynchronizer) resolveCommittee() error {
 // Start starts the synchronizer
 func (bs *BatchSynchronizer) Start() {
 	log.Infof("starting batch synchronizer, DAC addr: %v", bs.self)
-	go bs.handleUnresolvedBatchesMonitor()
+	go bs.startUnresolvedBatchesProcessor()
 	go bs.consumeEvents()
 	go bs.produceEvents()
 	go bs.handleReorgs()
@@ -234,7 +234,7 @@ func (bs *BatchSynchronizer) handleEvent(event *polygonvalidium.PolygonvalidiumS
 	return storeUnresolvedBatchKeys(bs.db, batchKeys)
 }
 
-func (bs *BatchSynchronizer) handleUnresolvedBatchesMonitor() {
+func (bs *BatchSynchronizer) startUnresolvedBatchesProcessor() {
 	log.Info("starting handling unresolved batches")
 	for {
 		delay := time.NewTimer(bs.retry)

--- a/synchronizer/batches_test.go
+++ b/synchronizer/batches_test.go
@@ -91,9 +91,9 @@ func TestBatchSynchronizer_Resolve(t *testing.T) {
 	}
 
 	data := common.HexToHash("0xFFFF").Bytes()
-	batchKey := batchKey{
-		number: 1,
-		hash:   crypto.Keccak256Hash(data),
+	batchKey := types.BatchKey{
+		Number: 1,
+		Hash:   crypto.Keccak256Hash(data),
 	}
 
 	testFn := func(config testConfig) {
@@ -139,7 +139,7 @@ func TestBatchSynchronizer_Resolve(t *testing.T) {
 			}
 		} else {
 			require.NoError(t, err)
-			require.Equal(t, batchKey.hash, offChainData.Key)
+			require.Equal(t, batchKey.Hash, offChainData.Key)
 			require.Equal(t, data, offChainData.Value)
 		}
 
@@ -153,9 +153,9 @@ func TestBatchSynchronizer_Resolve(t *testing.T) {
 		t.Parallel()
 
 		testFn(testConfig{
-			getSequenceBatchArgs: []interface{}{batchKey.number},
+			getSequenceBatchArgs: []interface{}{batchKey.Number},
 			getSequenceBatchReturns: []interface{}{&sequencer.SeqBatch{
-				Number:      types.ArgUint64(batchKey.number),
+				Number:      types.ArgUint64(batchKey.Number),
 				BatchL2Data: types.ArgBytes(data),
 			}, nil},
 		})
@@ -179,9 +179,9 @@ func TestBatchSynchronizer_Resolve(t *testing.T) {
 
 		testFn(testConfig{
 			isErrorExpected:                false,
-			getOffChainDataArgs:            [][]interface{}{{mock.Anything, batchKey.hash}},
+			getOffChainDataArgs:            [][]interface{}{{mock.Anything, batchKey.Hash}},
 			getOffChainDataReturns:         [][]interface{}{{data, nil}},
-			getSequenceBatchArgs:           []interface{}{batchKey.number},
+			getSequenceBatchArgs:           []interface{}{batchKey.Number},
 			getSequenceBatchReturns:        []interface{}{nil, errors.New("error")},
 			getCurrentDataCommitteeReturns: []interface{}{committee, nil},
 			newArgs:                        [][]interface{}{{committee.Members[0].URL}},
@@ -205,15 +205,15 @@ func TestBatchSynchronizer_Resolve(t *testing.T) {
 		}
 
 		testFn(testConfig{
-			getSequenceBatchArgs:           []interface{}{batchKey.number},
+			getSequenceBatchArgs:           []interface{}{batchKey.Number},
 			getSequenceBatchReturns:        []interface{}{nil, errors.New("error")},
 			getCurrentDataCommitteeReturns: []interface{}{committee, nil},
 			newArgs: [][]interface{}{
 				{committee.Members[0].URL},
 				{committee.Members[1].URL}},
 			getOffChainDataArgs: [][]interface{}{
-				{mock.Anything, batchKey.hash},
-				{mock.Anything, batchKey.hash},
+				{mock.Anything, batchKey.Hash},
+				{mock.Anything, batchKey.Hash},
 			},
 			getOffChainDataReturns: [][]interface{}{
 				{nil, errors.New("error")}, // member doesn't have batch
@@ -247,14 +247,14 @@ func TestBatchSynchronizer_Resolve(t *testing.T) {
 				{committee.Members[0].URL},
 				{committee.Members[1].URL}},
 			getOffChainDataArgs: [][]interface{}{
-				{mock.Anything, batchKey.hash},
-				{mock.Anything, batchKey.hash},
+				{mock.Anything, batchKey.Hash},
+				{mock.Anything, batchKey.Hash},
 			},
 			getOffChainDataReturns: [][]interface{}{
 				{[]byte{0, 0, 0, 1}, nil}, // member doesn't have batch
 				{[]byte{0, 0, 0, 1}, nil}, // member doesn't have batch
 			},
-			getSequenceBatchArgs:           []interface{}{batchKey.number},
+			getSequenceBatchArgs:           []interface{}{batchKey.Number},
 			getSequenceBatchReturns:        []interface{}{nil, errors.New("error")},
 			getCurrentDataCommitteeReturns: []interface{}{committee, nil},
 		})

--- a/synchronizer/store.go
+++ b/synchronizer/store.go
@@ -59,7 +59,64 @@ func exists(db dbTypes.DB, key common.Hash) bool {
 	return db.Exists(ctx, key)
 }
 
-func store(db dbTypes.DB, data []types.OffChainData) error {
+func storeUnresolvedBatchKeys(db dbTypes.DB, keys []types.BatchKey) error {
+	ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	defer cancel()
+
+	var (
+		dbTx dbTypes.Tx
+		err  error
+	)
+
+	if dbTx, err = db.BeginStateTransaction(ctx); err != nil {
+		return err
+	}
+
+	if err = db.StoreUnresolvedBatchKeys(ctx, keys, dbTx); err != nil {
+		rollback(err, dbTx)
+		return err
+	}
+
+	if err = dbTx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getUnresolvedBatchKeys(db dbTypes.DB) ([]types.BatchKey, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	defer cancel()
+
+	return db.GetUnresolvedBatchKeys(ctx)
+}
+
+func deleteUnresolvedBatchKeys(db dbTypes.DB, keys []types.BatchKey) error {
+	ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	defer cancel()
+
+	var (
+		dbTx dbTypes.Tx
+		err  error
+	)
+
+	if dbTx, err = db.BeginStateTransaction(ctx); err != nil {
+		return err
+	}
+
+	if err = db.DeleteUnresolvedBatchKeys(ctx, keys, dbTx); err != nil {
+		rollback(err, dbTx)
+		return err
+	}
+
+	if err = dbTx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func storeOffchainData(db dbTypes.DB, data []types.OffChainData) error {
 	ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
 	defer cancel()
 

--- a/synchronizer/store_test.go
+++ b/synchronizer/store_test.go
@@ -233,7 +233,7 @@ func Test_store(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testDB := tt.db(t)
 
-			if err := store(testDB, tt.data); tt.wantErr {
+			if err := storeOffchainData(testDB, tt.data); tt.wantErr {
 				require.ErrorIs(t, err, testError)
 			} else {
 				require.NoError(t, err)

--- a/synchronizer/store_test.go
+++ b/synchronizer/store_test.go
@@ -12,6 +12,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_getStartBlock(t *testing.T) {
+	testError := errors.New("test error")
+
+	tests := []struct {
+		name    string
+		db      func(t *testing.T) db.DB
+		block   uint64
+		wantErr bool
+	}{
+		{
+			name: "GetLastProcessedBlock returns error",
+			db: func(t *testing.T) db.DB {
+				mockDB := mocks.NewDB(t)
+
+				mockDB.On("GetLastProcessedBlock", mock.Anything, "L1").
+					Return(uint64(0), testError)
+
+				return mockDB
+			},
+			block:   0,
+			wantErr: true,
+		},
+		{
+			name: "all good",
+			db: func(t *testing.T) db.DB {
+				mockDB := mocks.NewDB(t)
+
+				mockDB.On("GetLastProcessedBlock", mock.Anything, "L1").Return(uint64(5), nil)
+
+				return mockDB
+			},
+			block: 4,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDB := tt.db(t)
+
+			if block, err := getStartBlock(testDB); tt.wantErr {
+				require.ErrorIs(t, err, testError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.block, block)
+			}
+		})
+	}
+}
+
 func Test_setStartBlock(t *testing.T) {
 	testError := errors.New("test error")
 
@@ -148,7 +196,249 @@ func Test_exists(t *testing.T) {
 	}
 }
 
-func Test_store(t *testing.T) {
+func Test_storeUnresolvedBatchKeys(t *testing.T) {
+	testError := errors.New("test error")
+	testData := []types.BatchKey{
+		{
+			Number: 1,
+			Hash:   common.HexToHash("0x01"),
+		},
+	}
+
+	tests := []struct {
+		name    string
+		db      func(t *testing.T) db.DB
+		keys    []types.BatchKey
+		wantErr bool
+	}{
+		{
+			name: "BeginStateTransaction returns error",
+			db: func(t *testing.T) db.DB {
+				mockDB := mocks.NewDB(t)
+
+				mockDB.On("BeginStateTransaction", mock.Anything).Return(nil, testError)
+
+				return mockDB
+			},
+			keys:    testData,
+			wantErr: true,
+		},
+		{
+			name: "StoreUnresolvedBatchKeys returns error",
+			db: func(t *testing.T) db.DB {
+				mockDB := mocks.NewDB(t)
+
+				mockTx := mocks.NewTx(t)
+
+				mockDB.On("BeginStateTransaction", mock.Anything).Return(mockTx, nil)
+
+				mockDB.On("StoreUnresolvedBatchKeys", mock.Anything, testData, mockTx).Return(testError)
+
+				mockTx.On("Rollback").Return(nil)
+
+				return mockDB
+			},
+			keys:    testData,
+			wantErr: true,
+		},
+		{
+			name: "Commit returns error",
+			db: func(t *testing.T) db.DB {
+				mockDB := mocks.NewDB(t)
+
+				mockTx := mocks.NewTx(t)
+
+				mockDB.On("BeginStateTransaction", mock.Anything).Return(mockTx, nil)
+
+				mockDB.On("StoreUnresolvedBatchKeys", mock.Anything, testData, mockTx).Return(nil)
+
+				mockTx.On("Commit").Return(testError)
+
+				return mockDB
+			},
+			keys:    testData,
+			wantErr: true,
+		},
+		{
+			name: "all good",
+			db: func(t *testing.T) db.DB {
+				mockDB := mocks.NewDB(t)
+
+				mockTx := mocks.NewTx(t)
+
+				mockDB.On("BeginStateTransaction", mock.Anything).Return(mockTx, nil)
+
+				mockDB.On("StoreUnresolvedBatchKeys", mock.Anything, testData, mockTx).Return(nil)
+
+				mockTx.On("Commit").Return(nil)
+
+				return mockDB
+			},
+			keys: testData,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDB := tt.db(t)
+
+			if err := storeUnresolvedBatchKeys(testDB, tt.keys); tt.wantErr {
+				require.ErrorIs(t, err, testError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_getUnresolvedBatchKeys(t *testing.T) {
+	testError := errors.New("test error")
+	testData := []types.BatchKey{
+		{
+			Number: 1,
+			Hash:   common.HexToHash("0x01"),
+		},
+	}
+
+	tests := []struct {
+		name    string
+		db      func(t *testing.T) db.DB
+		keys    []types.BatchKey
+		wantErr bool
+	}{
+		{
+			name: "GetUnresolvedBatchKeys returns error",
+			db: func(t *testing.T) db.DB {
+				mockDB := mocks.NewDB(t)
+
+				mockDB.On("GetUnresolvedBatchKeys", mock.Anything).
+					Return(nil, testError)
+
+				return mockDB
+			},
+			wantErr: true,
+		},
+		{
+			name: "all good",
+			db: func(t *testing.T) db.DB {
+				mockDB := mocks.NewDB(t)
+
+				mockDB.On("GetUnresolvedBatchKeys", mock.Anything).Return(testData, nil)
+
+				return mockDB
+			},
+			keys: testData,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDB := tt.db(t)
+
+			if keys, err := getUnresolvedBatchKeys(testDB); tt.wantErr {
+				require.ErrorIs(t, err, testError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.keys, keys)
+			}
+		})
+	}
+}
+
+func Test_deleteUnresolvedBatchKeys(t *testing.T) {
+	testError := errors.New("test error")
+	testData := []types.BatchKey{
+		{
+			Number: 1,
+			Hash:   common.HexToHash("0x01"),
+		},
+	}
+
+	tests := []struct {
+		name    string
+		db      func(t *testing.T) db.DB
+		wantErr bool
+	}{
+		{
+			name: "BeginStateTransaction returns error",
+			db: func(t *testing.T) db.DB {
+				mockDB := mocks.NewDB(t)
+
+				mockDB.On("BeginStateTransaction", mock.Anything).
+					Return(nil, testError)
+
+				return mockDB
+			},
+			wantErr: true,
+		},
+		{
+			name: "DeleteUnresolvedBatchKeys returns error",
+			db: func(t *testing.T) db.DB {
+				mockDB := mocks.NewDB(t)
+
+				mockTx := mocks.NewTx(t)
+
+				mockDB.On("BeginStateTransaction", mock.Anything).Return(mockTx, nil)
+
+				mockDB.On("DeleteUnresolvedBatchKeys", mock.Anything, testData, mockTx).
+					Return(testError)
+
+				mockTx.On("Rollback").Return(nil)
+
+				return mockDB
+			},
+			wantErr: true,
+		},
+		{
+			name: "Commit returns error",
+			db: func(t *testing.T) db.DB {
+				mockDB := mocks.NewDB(t)
+
+				mockTx := mocks.NewTx(t)
+
+				mockDB.On("BeginStateTransaction", mock.Anything).Return(mockTx, nil)
+
+				mockDB.On("DeleteUnresolvedBatchKeys", mock.Anything, testData, mockTx).
+					Return(nil)
+
+				mockTx.On("Commit").
+					Return(testError)
+
+				return mockDB
+			},
+			wantErr: true,
+		},
+		{
+			name: "all good",
+			db: func(t *testing.T) db.DB {
+				mockDB := mocks.NewDB(t)
+
+				mockTx := mocks.NewTx(t)
+
+				mockDB.On("BeginStateTransaction", mock.Anything).Return(mockTx, nil)
+
+				mockDB.On("DeleteUnresolvedBatchKeys", mock.Anything, testData, mockTx).
+					Return(nil)
+
+				mockTx.On("Commit").
+					Return(nil)
+
+				return mockDB
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDB := tt.db(t)
+
+			if err := deleteUnresolvedBatchKeys(testDB, testData); tt.wantErr {
+				require.ErrorIs(t, err, testError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_storeOffchainData(t *testing.T) {
 	testError := errors.New("test error")
 	testData := []types.OffChainData{
 		{

--- a/types/types.go
+++ b/types/types.go
@@ -15,6 +15,12 @@ const (
 	hexBitSize64 = 64
 )
 
+// BatchKey is the pairing of batch number and data hash of a batch
+type BatchKey struct {
+	Number uint64
+	Hash   common.Hash
+}
+
 // OffChainData represents some data that is not stored on chain and should be preserved
 type OffChainData struct {
 	Key   common.Hash


### PR DESCRIPTION
The logic is going to be the following:
### Process 1

- Get batches from the incoming event.
- Store batches into "unresolved_batches" table.

### Process 2

- Get records from "unresolved_batches" table.
- Filter really unresolved batches by checking the hash in "offchain_data" table.
- Delete existing (resolved) batches from "unresolved_batches" table if exists. It might happen in theory.
- Resolve unresolved bathes.
- Delete resolved batches from "unresolved_batches" table.