### PR TITLE
Added genesis block of L1 contract to DAC config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,9 @@ type L1Config struct {
 	Timeout                types.Duration `mapstructure:"Timeout"`
 	RetryPeriod            types.Duration `mapstructure:"RetryPeriod"`
 	BlockBatchSize         uint           `mapstructure:"BlockBatchSize"`
+
+	// GenesisBlock represents the block number where PolygonValidium contract is deployed on L1
+	GenesisBlock uint64 `mapstructure:"GenesisBlock"`
 }
 
 // Load loads the configuration baseed on the cli context

--- a/config/default.go
+++ b/config/default.go
@@ -19,6 +19,7 @@ DataCommitteeAddress = "0x68B1D87F95878fE05B998F19b66F4baba5De1aed"
 Timeout = "1m"
 RetryPeriod = "5s"
 BlockBatchSize = "64"
+GenesisBlock = "0"
 
 [Log]
 Environment = "development" # "production" or "development"

--- a/synchronizer/init.go
+++ b/synchronizer/init.go
@@ -37,9 +37,14 @@ func InitStartBlock(db db.DB, ethClientFactory types.EthClientFactory, l1 config
 		return err
 	}
 
-	startBlock, err := findContractDeploymentBlock(ctx, ethClient, common.HexToAddress(l1.PolygonValidiumAddress))
-	if err != nil {
-		return err
+	startBlock := new(big.Int)
+	if l1.GenesisBlock != 0 {
+		startBlock.SetUint64(l1.GenesisBlock)
+	} else {
+		startBlock, err = findContractDeploymentBlock(ctx, ethClient, common.HexToAddress(l1.PolygonValidiumAddress))
+		if err != nil {
+			return err
+		}
 	}
 
 	return setStartBlock(db, startBlock.Uint64())


### PR DESCRIPTION
Synchronizer can avoid the init routine of finding the block where contract is deployed on L1 if GenesisBlock number is provided in the config file