### PR TITLE
Make DAC ws config tracking optional

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ type L1Config struct {
 	Timeout                types.Duration `mapstructure:"Timeout"`
 	RetryPeriod            types.Duration `mapstructure:"RetryPeriod"`
 	BlockBatchSize         uint           `mapstructure:"BlockBatchSize"`
+	TrackSequencer         bool           `mapstructure:"TrackSequencer"`
 
 	// GenesisBlock represents the block number where PolygonValidium contract is deployed on L1
 	GenesisBlock uint64 `mapstructure:"GenesisBlock"`

--- a/config/default.go
+++ b/config/default.go
@@ -20,6 +20,7 @@ Timeout = "1m"
 RetryPeriod = "5s"
 BlockBatchSize = "64"
 GenesisBlock = "0"
+TrackSequencer = true
 
 [Log]
 Environment = "development" # "production" or "development"

--- a/docs/running.md
+++ b/docs/running.md
@@ -83,6 +83,7 @@ DataCommitteeAddress = "0x68B1D87F95878fE05B998F19b66F4baba5De1aed"     # CHANGE
 Timeout = "3m"
 RetryPeriod = "5s"
 BlockBatchSize = 32
+TrackSequencer = true
 
 [Log]
 Environment = "development" # "production" or "development"

--- a/sequencer/tracker.go
+++ b/sequencer/tracker.go
@@ -83,6 +83,7 @@ func (st *Tracker) setUrl(url string) {
 func (st *Tracker) Start(ctx context.Context) {
 	st.startOnce.Do(func() {
 		if !st.trackChanges {
+			log.Info("sequencer tracking disabled")
 			return
 		}
 

--- a/sequencer/tracker.go
+++ b/sequencer/tracker.go
@@ -14,14 +14,15 @@ import (
 
 // Tracker watches the contract for relevant changes to the sequencer
 type Tracker struct {
-	client    etherman.Etherman
-	stop      chan struct{}
-	timeout   time.Duration
-	retry     time.Duration
-	addr      common.Address
-	url       string
-	lock      sync.Mutex
-	startOnce sync.Once
+	client       etherman.Etherman
+	stop         chan struct{}
+	timeout      time.Duration
+	retry        time.Duration
+	addr         common.Address
+	url          string
+	trackChanges bool
+	lock         sync.Mutex
+	startOnce    sync.Once
 }
 
 // NewTracker creates a new Tracker
@@ -40,12 +41,13 @@ func NewTracker(cfg config.L1Config, ethClient etherman.Etherman) (*Tracker, err
 
 	log.Infof("current sequencer url: %s", url)
 	w := &Tracker{
-		client:  ethClient,
-		stop:    make(chan struct{}),
-		timeout: cfg.Timeout.Duration,
-		retry:   cfg.RetryPeriod.Duration,
-		addr:    addr,
-		url:     url,
+		client:       ethClient,
+		stop:         make(chan struct{}),
+		timeout:      cfg.Timeout.Duration,
+		retry:        cfg.RetryPeriod.Duration,
+		addr:         addr,
+		url:          url,
+		trackChanges: cfg.TrackSequencer,
 	}
 
 	return w, nil
@@ -80,6 +82,10 @@ func (st *Tracker) setUrl(url string) {
 // Start starts the SequencerTracker
 func (st *Tracker) Start(ctx context.Context) {
 	st.startOnce.Do(func() {
+		if !st.trackChanges {
+			return
+		}
+
 		go st.trackAddrChanges(ctx)
 		go st.trackUrlChanges(ctx)
 	})

--- a/sequencer/tracker_test.go
+++ b/sequencer/tracker_test.go
@@ -84,77 +84,111 @@ func Test_NewTracker(t *testing.T) {
 }
 
 func TestTracker(t *testing.T) {
-	var (
-		addressesChan chan *polygonvalidium.PolygonvalidiumSetTrustedSequencer
-		urlsChan      chan *polygonvalidium.PolygonvalidiumSetTrustedSequencerURL
-	)
+	t.Run("with enabled tracker", func(t *testing.T) {
+		var (
+			addressesChan chan *polygonvalidium.PolygonvalidiumSetTrustedSequencer
+			urlsChan      chan *polygonvalidium.PolygonvalidiumSetTrustedSequencerURL
+		)
 
-	ctx := context.Background()
+		ctx := context.Background()
 
-	etherman := mocks.NewEtherman(t)
-	defer etherman.AssertExpectations(t)
+		etherman := mocks.NewEtherman(t)
+		defer etherman.AssertExpectations(t)
 
-	etherman.On("TrustedSequencer").Return(common.Address{}, nil)
-	etherman.On("TrustedSequencerURL").Return("127.0.0.1:8585", nil)
+		etherman.On("TrustedSequencer").Return(common.Address{}, nil)
+		etherman.On("TrustedSequencerURL").Return("127.0.0.1:8585", nil)
 
-	addressesSubscription := mocks.NewSubscription(t)
-	defer addressesSubscription.AssertExpectations(t)
+		addressesSubscription := mocks.NewSubscription(t)
+		defer addressesSubscription.AssertExpectations(t)
 
-	addressesSubscription.On("Err").Return(make(<-chan error))
-	addressesSubscription.On("Unsubscribe").Return()
+		addressesSubscription.On("Err").Return(make(<-chan error))
+		addressesSubscription.On("Unsubscribe").Return()
 
-	etherman.On("WatchSetTrustedSequencer", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			var ok bool
-			addressesChan, ok = args[1].(chan *polygonvalidium.PolygonvalidiumSetTrustedSequencer)
-			require.True(t, ok)
-		}).
-		Return(addressesSubscription, nil)
+		etherman.On("WatchSetTrustedSequencer", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				var ok bool
+				addressesChan, ok = args[1].(chan *polygonvalidium.PolygonvalidiumSetTrustedSequencer)
+				require.True(t, ok)
+			}).
+			Return(addressesSubscription, nil)
 
-	urlsSubscription := mocks.NewSubscription(t)
-	defer urlsSubscription.AssertExpectations(t)
+		urlsSubscription := mocks.NewSubscription(t)
+		defer urlsSubscription.AssertExpectations(t)
 
-	urlsSubscription.On("Err").Return(make(<-chan error))
-	urlsSubscription.On("Unsubscribe").Return()
+		urlsSubscription.On("Err").Return(make(<-chan error))
+		urlsSubscription.On("Unsubscribe").Return()
 
-	etherman.On("WatchSetTrustedSequencerURL", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			var ok bool
-			urlsChan, ok = args[1].(chan *polygonvalidium.PolygonvalidiumSetTrustedSequencerURL)
-			require.True(t, ok)
-		}).
-		Return(urlsSubscription, nil)
+		etherman.On("WatchSetTrustedSequencerURL", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				var ok bool
+				urlsChan, ok = args[1].(chan *polygonvalidium.PolygonvalidiumSetTrustedSequencerURL)
+				require.True(t, ok)
+			}).
+			Return(urlsSubscription, nil)
 
-	tracker, err := sequencer.NewTracker(config.L1Config{
-		Timeout:     types.NewDuration(time.Second * 10),
-		RetryPeriod: types.NewDuration(time.Millisecond),
-	}, etherman)
-	require.NoError(t, err)
+		tracker, err := sequencer.NewTracker(config.L1Config{
+			Timeout:        types.NewDuration(time.Second * 10),
+			RetryPeriod:    types.NewDuration(time.Millisecond),
+			TrackSequencer: true,
+		}, etherman)
+		require.NoError(t, err)
 
-	tracker.Start(ctx)
+		require.Equal(t, common.Address{}, tracker.GetAddr())
+		require.Equal(t, "127.0.0.1:8585", tracker.GetUrl())
 
-	var (
-		updatedAddress = common.BytesToAddress([]byte("updated"))
-		updatedURL     = "127.0.0.1:9585"
-	)
+		tracker.Start(ctx)
 
-	eventually(t, 10, func() bool {
-		return addressesChan != nil && urlsChan != nil
+		var (
+			updatedAddress = common.BytesToAddress([]byte("updated"))
+			updatedURL     = "127.0.0.1:9585"
+		)
+
+		eventually(t, 10, func() bool {
+			return addressesChan != nil && urlsChan != nil
+		})
+
+		addressesChan <- &polygonvalidium.PolygonvalidiumSetTrustedSequencer{
+			NewTrustedSequencer: updatedAddress,
+		}
+
+		urlsChan <- &polygonvalidium.PolygonvalidiumSetTrustedSequencerURL{
+			NewTrustedSequencerURL: updatedURL,
+		}
+
+		tracker.Stop()
+
+		// Wait for values to be updated
+		eventually(t, 10, func() bool {
+			return tracker.GetAddr() == updatedAddress && tracker.GetUrl() == updatedURL
+		})
 	})
 
-	addressesChan <- &polygonvalidium.PolygonvalidiumSetTrustedSequencer{
-		NewTrustedSequencer: updatedAddress,
-	}
+	t.Run("with disabled tracker", func(t *testing.T) {
+		ctx := context.Background()
 
-	urlsChan <- &polygonvalidium.PolygonvalidiumSetTrustedSequencerURL{
-		NewTrustedSequencerURL: updatedURL,
-	}
+		etherman := mocks.NewEtherman(t)
+		defer etherman.AssertExpectations(t)
 
-	tracker.Stop()
+		etherman.On("TrustedSequencer").Return(common.Address{}, nil)
+		etherman.On("TrustedSequencerURL").Return("127.0.0.1:8585", nil)
 
-	// Wait for values to be updated
-	eventually(t, 10, func() bool {
-		return tracker.GetAddr() == updatedAddress && tracker.GetUrl() == updatedURL
+		tracker, err := sequencer.NewTracker(config.L1Config{
+			Timeout:     types.NewDuration(time.Second * 10),
+			RetryPeriod: types.NewDuration(time.Millisecond),
+		}, etherman)
+		require.NoError(t, err)
+
+		require.Equal(t, common.Address{}, tracker.GetAddr())
+		require.Equal(t, "127.0.0.1:8585", tracker.GetUrl())
+
+		tracker.Start(ctx)
+
+		time.Sleep(time.Second)
+
+		tracker.Stop()
+
+		require.Equal(t, common.Address{}, tracker.GetAddr())
+		require.Equal(t, "127.0.0.1:8585", tracker.GetUrl())
 	})
 }
 

--- a/test/config/test.dev.toml
+++ b/test/config/test.dev.toml
@@ -7,7 +7,7 @@ PolygonValidiumAddress = "0x0775AAFB6dD38417581F7C583053Fa3B78FD4FD1"
 DataCommitteeAddress = "0xE660928f13F51bEbb553063A1317EDC0e7038949"
 Timeout = "1m"
 RetryPeriod = "5s"
-
+TrackSequencer = true
 
 [Log]
 Environment = "development" # "production" or "development"

--- a/test/config/test.docker.toml
+++ b/test/config/test.docker.toml
@@ -8,6 +8,7 @@ DataCommitteeAddress = "0x68B1D87F95878fE05B998F19b66F4baba5De1aed"
 Timeout = "3m"
 RetryPeriod = "5s"
 BlockBatchSize = 32
+TrackSequencer = true
 
 [Log]
 Environment = "development" # "production" or "development"

--- a/test/config/test.local.toml
+++ b/test/config/test.local.toml
@@ -8,6 +8,7 @@ DataCommitteeAddress = "0x68B1D87F95878fE05B998F19b66F4baba5De1aed"
 Timeout = "3m"
 RetryPeriod = "5s"
 BlockBatchSize = 8
+TrackSequencer = true
 
 [Log]
 Environment = "development" # "production" or "development"


### PR DESCRIPTION
Make the trackers that track url and addr config changes optional. Retain the initial lookup of the values, but optionally turn off the websocket event tracking.

This can help the gelato situation where they have flakey ws support, and don’t need the feature for now anyway. 