### PR TITLE
Added max connection retries number to the sequencer tracker

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,10 +110,7 @@ func start(cliCtx *cli.Context) error {
 
 	var cancelFuncs []context.CancelFunc
 
-	sequencerTracker, err := sequencer.NewTracker(c.L1, etm)
-	if err != nil {
-		log.Fatal(err)
-	}
+	sequencerTracker := sequencer.NewTracker(c.L1, etm)
 	go sequencerTracker.Start(cliCtx.Context)
 	cancelFuncs = append(cancelFuncs, sequencerTracker.Stop)
 
@@ -122,8 +119,7 @@ func start(cliCtx *cli.Context) error {
 		log.Fatal(err)
 	}
 
-	err = detector.Start()
-	if err != nil {
+	if err = detector.Start(); err != nil {
 		log.Fatal(err)
 	}
 
@@ -157,7 +153,7 @@ func start(cliCtx *cli.Context) error {
 	)
 
 	// Run!
-	if err := server.Start(); err != nil {
+	if err = server.Start(); err != nil {
 		log.Fatal(err)
 	}
 

--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -34,12 +34,12 @@ type Etherman interface {
 	GetCurrentDataCommittee() (*DataCommittee, error)
 	GetCurrentDataCommitteeMembers() ([]DataCommitteeMember, error)
 	GetTx(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error)
-	TrustedSequencer() (common.Address, error)
+	TrustedSequencer(ctx context.Context) (common.Address, error)
 	WatchSetTrustedSequencer(
 		ctx context.Context,
 		events chan *polygonvalidium.PolygonvalidiumSetTrustedSequencer,
 	) (event.Subscription, error)
-	TrustedSequencerURL() (string, error)
+	TrustedSequencerURL(ctx context.Context) (string, error)
 	WatchSetTrustedSequencerURL(
 		ctx context.Context,
 		events chan *polygonvalidium.PolygonvalidiumSetTrustedSequencerURL,
@@ -98,8 +98,11 @@ func (e *etherman) GetTx(ctx context.Context, txHash common.Hash) (*types.Transa
 }
 
 // TrustedSequencer gets trusted sequencer address
-func (e *etherman) TrustedSequencer() (common.Address, error) {
-	return e.CDKValidium.TrustedSequencer(&bind.CallOpts{Pending: false})
+func (e *etherman) TrustedSequencer(ctx context.Context) (common.Address, error) {
+	return e.CDKValidium.TrustedSequencer(&bind.CallOpts{
+		Context: ctx,
+		Pending: false,
+	})
 }
 
 // WatchSetTrustedSequencer watches trusted sequencer address
@@ -111,8 +114,11 @@ func (e *etherman) WatchSetTrustedSequencer(
 }
 
 // TrustedSequencerURL gets trusted sequencer's RPC url
-func (e *etherman) TrustedSequencerURL() (string, error) {
-	return e.CDKValidium.TrustedSequencerURL(&bind.CallOpts{Pending: false})
+func (e *etherman) TrustedSequencerURL(ctx context.Context) (string, error) {
+	return e.CDKValidium.TrustedSequencerURL(&bind.CallOpts{
+		Context: ctx,
+		Pending: false,
+	})
 }
 
 // WatchSetTrustedSequencerURL watches trusted sequencer's RPC url

--- a/mocks/etherman.generated.go
+++ b/mocks/etherman.generated.go
@@ -332,9 +332,9 @@ func (_c *Etherman_HeaderByNumber_Call) RunAndReturn(run func(context.Context, *
 	return _c
 }
 
-// TrustedSequencer provides a mock function with given fields:
-func (_m *Etherman) TrustedSequencer() (common.Address, error) {
-	ret := _m.Called()
+// TrustedSequencer provides a mock function with given fields: ctx
+func (_m *Etherman) TrustedSequencer(ctx context.Context) (common.Address, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for TrustedSequencer")
@@ -342,19 +342,19 @@ func (_m *Etherman) TrustedSequencer() (common.Address, error) {
 
 	var r0 common.Address
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (common.Address, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (common.Address, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() common.Address); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) common.Address); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Address)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -368,13 +368,14 @@ type Etherman_TrustedSequencer_Call struct {
 }
 
 // TrustedSequencer is a helper method to define mock.On call
-func (_e *Etherman_Expecter) TrustedSequencer() *Etherman_TrustedSequencer_Call {
-	return &Etherman_TrustedSequencer_Call{Call: _e.mock.On("TrustedSequencer")}
+//   - ctx context.Context
+func (_e *Etherman_Expecter) TrustedSequencer(ctx interface{}) *Etherman_TrustedSequencer_Call {
+	return &Etherman_TrustedSequencer_Call{Call: _e.mock.On("TrustedSequencer", ctx)}
 }
 
-func (_c *Etherman_TrustedSequencer_Call) Run(run func()) *Etherman_TrustedSequencer_Call {
+func (_c *Etherman_TrustedSequencer_Call) Run(run func(ctx context.Context)) *Etherman_TrustedSequencer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -384,14 +385,14 @@ func (_c *Etherman_TrustedSequencer_Call) Return(_a0 common.Address, _a1 error) 
 	return _c
 }
 
-func (_c *Etherman_TrustedSequencer_Call) RunAndReturn(run func() (common.Address, error)) *Etherman_TrustedSequencer_Call {
+func (_c *Etherman_TrustedSequencer_Call) RunAndReturn(run func(context.Context) (common.Address, error)) *Etherman_TrustedSequencer_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// TrustedSequencerURL provides a mock function with given fields:
-func (_m *Etherman) TrustedSequencerURL() (string, error) {
-	ret := _m.Called()
+// TrustedSequencerURL provides a mock function with given fields: ctx
+func (_m *Etherman) TrustedSequencerURL(ctx context.Context) (string, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for TrustedSequencerURL")
@@ -399,17 +400,17 @@ func (_m *Etherman) TrustedSequencerURL() (string, error) {
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (string, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -423,13 +424,14 @@ type Etherman_TrustedSequencerURL_Call struct {
 }
 
 // TrustedSequencerURL is a helper method to define mock.On call
-func (_e *Etherman_Expecter) TrustedSequencerURL() *Etherman_TrustedSequencerURL_Call {
-	return &Etherman_TrustedSequencerURL_Call{Call: _e.mock.On("TrustedSequencerURL")}
+//   - ctx context.Context
+func (_e *Etherman_Expecter) TrustedSequencerURL(ctx interface{}) *Etherman_TrustedSequencerURL_Call {
+	return &Etherman_TrustedSequencerURL_Call{Call: _e.mock.On("TrustedSequencerURL", ctx)}
 }
 
-func (_c *Etherman_TrustedSequencerURL_Call) Run(run func()) *Etherman_TrustedSequencerURL_Call {
+func (_c *Etherman_TrustedSequencerURL_Call) Run(run func(ctx context.Context)) *Etherman_TrustedSequencerURL_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -439,7 +441,7 @@ func (_c *Etherman_TrustedSequencerURL_Call) Return(_a0 string, _a1 error) *Ethe
 	return _c
 }
 
-func (_c *Etherman_TrustedSequencerURL_Call) RunAndReturn(run func() (string, error)) *Etherman_TrustedSequencerURL_Call {
+func (_c *Etherman_TrustedSequencerURL_Call) RunAndReturn(run func(context.Context) (string, error)) *Etherman_TrustedSequencerURL_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -1,0 +1,16 @@
+package backoff
+
+import "time"
+
+// Exponential performs exponential backoff attempts on a given action
+func Exponential(action func() error, max uint, wait time.Duration) error {
+	var err error
+	for i := uint(0); i < max; i++ {
+		if err = action(); err == nil {
+			return nil
+		}
+		time.Sleep(wait)
+		wait *= 2
+	}
+	return err
+}

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -1,0 +1,46 @@
+package backoff
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExponential(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		i := 0
+		outcomes := []bool{false, false, true}
+		t0 := time.Now()
+		err := Exponential(func() error {
+			outcome := outcomes[i]
+			i++
+			if outcome {
+				return nil
+			}
+			return errors.New("bad")
+		}, 3, 150*time.Millisecond)
+
+		elapsed := time.Since(t0)
+
+		require.NoError(t, err)
+		require.Equal(t, i, 3)
+		require.True(t, elapsed >= 450*time.Millisecond)
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		i := 0
+		t0 := time.Now()
+		err := Exponential(func() error {
+			i++
+			return errors.New("bad")
+		}, 3, 100*time.Millisecond)
+
+		elapsed := time.Since(t0)
+
+		require.Error(t, err)
+		require.Equal(t, i, 3)
+		require.True(t, elapsed >= 600*time.Millisecond)
+	})
+}

--- a/sequencer/tracker.go
+++ b/sequencer/tracker.go
@@ -14,6 +14,11 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 )
 
+const (
+	// maxConnectionRetries is the maximum number of retries to connect to the RPC node before failing.
+	maxConnectionRetries = 5
+)
+
 // Tracker watches the contract for relevant changes to the sequencer
 type Tracker struct {
 	client       etherman.Etherman
@@ -110,7 +115,7 @@ func (st *Tracker) trackAddrChanges(ctx context.Context) {
 			}
 
 			return err
-		}, 5, st.retry); err != nil {
+		}, maxConnectionRetries, st.retry); err != nil {
 			log.Fatalf("failed subscribing to trusted sequencer event: %v. Check ws(s) availability.", err)
 		}
 	}
@@ -151,7 +156,7 @@ func (st *Tracker) trackUrlChanges(ctx context.Context) {
 			}
 
 			return err
-		}, 5, st.retry); err != nil {
+		}, maxConnectionRetries, st.retry); err != nil {
 			log.Fatalf("failed subscribing to trusted sequencer URL event: %v. Check ws(s) availability.", err)
 		}
 	}

--- a/sequencer/tracker.go
+++ b/sequencer/tracker.go
@@ -5,12 +5,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0xPolygon/cdk-data-availability/pkg/backoff"
-
 	"github.com/0xPolygon/cdk-data-availability/config"
 	"github.com/0xPolygon/cdk-data-availability/etherman"
 	"github.com/0xPolygon/cdk-data-availability/etherman/smartcontracts/etrog/polygonvalidium"
 	"github.com/0xPolygon/cdk-data-availability/log"
+	"github.com/0xPolygon/cdk-data-availability/pkg/backoff"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
 )

--- a/sequencer/tracker_test.go
+++ b/sequencer/tracker_test.go
@@ -2,7 +2,6 @@ package sequencer_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -16,73 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_NewTracker(t *testing.T) {
-	testErr := errors.New("test error")
-
-	testTable := []struct {
-		name     string
-		initMock func(t *testing.T) *mocks.Etherman
-		err      error
-	}{
-		{
-			name: "successfully created tracker",
-			initMock: func(t *testing.T) *mocks.Etherman {
-				em := mocks.NewEtherman(t)
-
-				em.On("TrustedSequencer").Return(common.Address{}, nil)
-				em.On("TrustedSequencerURL").Return("127.0.0.1", nil)
-
-				return em
-			},
-		},
-		{
-			name: "TrustedSequencer returns error",
-			initMock: func(t *testing.T) *mocks.Etherman {
-				em := mocks.NewEtherman(t)
-
-				em.On("TrustedSequencer").Return(common.Address{}, testErr)
-
-				return em
-			},
-			err: testErr,
-		},
-		{
-			name: "TrustedSequencerURL returns error",
-			initMock: func(t *testing.T) *mocks.Etherman {
-				em := mocks.NewEtherman(t)
-
-				em.On("TrustedSequencer").Return(common.Address{}, nil)
-				em.On("TrustedSequencerURL").Return("", testErr)
-
-				return em
-			},
-			err: testErr,
-		},
-	}
-
-	for _, tt := range testTable {
-		tt := tt
-
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			em := tt.initMock(t)
-			defer em.AssertExpectations(t)
-
-			_, err := sequencer.NewTracker(config.L1Config{
-				Timeout:     types.NewDuration(time.Second * 10),
-				RetryPeriod: types.NewDuration(time.Millisecond),
-			}, em)
-			if tt.err != nil {
-				require.Error(t, err)
-				require.EqualError(t, tt.err, err.Error())
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestTracker(t *testing.T) {
 	t.Run("with enabled tracker", func(t *testing.T) {
 		var (
@@ -93,13 +25,11 @@ func TestTracker(t *testing.T) {
 		ctx := context.Background()
 
 		etherman := mocks.NewEtherman(t)
-		defer etherman.AssertExpectations(t)
 
-		etherman.On("TrustedSequencer").Return(common.Address{}, nil)
-		etherman.On("TrustedSequencerURL").Return("127.0.0.1:8585", nil)
+		etherman.On("TrustedSequencer", mock.Anything).Return(common.Address{}, nil)
+		etherman.On("TrustedSequencerURL", mock.Anything).Return("127.0.0.1:8585", nil)
 
 		addressesSubscription := mocks.NewSubscription(t)
-		defer addressesSubscription.AssertExpectations(t)
 
 		addressesSubscription.On("Err").Return(make(<-chan error))
 		addressesSubscription.On("Unsubscribe").Return()
@@ -113,7 +43,6 @@ func TestTracker(t *testing.T) {
 			Return(addressesSubscription, nil)
 
 		urlsSubscription := mocks.NewSubscription(t)
-		defer urlsSubscription.AssertExpectations(t)
 
 		urlsSubscription.On("Err").Return(make(<-chan error))
 		urlsSubscription.On("Unsubscribe").Return()
@@ -126,15 +55,14 @@ func TestTracker(t *testing.T) {
 			}).
 			Return(urlsSubscription, nil)
 
-		tracker, err := sequencer.NewTracker(config.L1Config{
+		tracker := sequencer.NewTracker(config.L1Config{
 			Timeout:        types.NewDuration(time.Second * 10),
 			RetryPeriod:    types.NewDuration(time.Millisecond),
 			TrackSequencer: true,
 		}, etherman)
-		require.NoError(t, err)
 
 		require.Equal(t, common.Address{}, tracker.GetAddr())
-		require.Equal(t, "127.0.0.1:8585", tracker.GetUrl())
+		require.Empty(t, tracker.GetUrl())
 
 		tracker.Start(ctx)
 
@@ -161,25 +89,27 @@ func TestTracker(t *testing.T) {
 		eventually(t, 10, func() bool {
 			return tracker.GetAddr() == updatedAddress && tracker.GetUrl() == updatedURL
 		})
+
+		urlsSubscription.AssertExpectations(t)
+		addressesSubscription.AssertExpectations(t)
+		etherman.AssertExpectations(t)
 	})
 
 	t.Run("with disabled tracker", func(t *testing.T) {
 		ctx := context.Background()
 
 		etherman := mocks.NewEtherman(t)
-		defer etherman.AssertExpectations(t)
 
-		etherman.On("TrustedSequencer").Return(common.Address{}, nil)
-		etherman.On("TrustedSequencerURL").Return("127.0.0.1:8585", nil)
+		etherman.On("TrustedSequencer", mock.Anything).Return(common.Address{}, nil)
+		etherman.On("TrustedSequencerURL", mock.Anything).Return("127.0.0.1:8585", nil)
 
-		tracker, err := sequencer.NewTracker(config.L1Config{
+		tracker := sequencer.NewTracker(config.L1Config{
 			Timeout:     types.NewDuration(time.Second * 10),
 			RetryPeriod: types.NewDuration(time.Millisecond),
 		}, etherman)
-		require.NoError(t, err)
 
 		require.Equal(t, common.Address{}, tracker.GetAddr())
-		require.Equal(t, "127.0.0.1:8585", tracker.GetUrl())
+		require.Empty(t, tracker.GetUrl())
 
 		tracker.Start(ctx)
 
@@ -189,6 +119,8 @@ func TestTracker(t *testing.T) {
 
 		require.Equal(t, common.Address{}, tracker.GetAddr())
 		require.Equal(t, "127.0.0.1:8585", tracker.GetUrl())
+
+		etherman.AssertExpectations(t)
 	})
 }
 

--- a/sequencer/tracker_test.go
+++ b/sequencer/tracker_test.go
@@ -16,6 +16,13 @@ import (
 )
 
 func TestTracker(t *testing.T) {
+	var (
+		initialAddress = common.BytesToAddress([]byte("initial"))
+		initialURL     = "127.0.0.1:8585"
+		updatedAddress = common.BytesToAddress([]byte("updated"))
+		updatedURL     = "127.0.0.1:9585"
+	)
+
 	t.Run("with enabled tracker", func(t *testing.T) {
 		var (
 			addressesChan chan *polygonvalidium.PolygonvalidiumSetTrustedSequencer
@@ -26,8 +33,8 @@ func TestTracker(t *testing.T) {
 
 		etherman := mocks.NewEtherman(t)
 
-		etherman.On("TrustedSequencer", mock.Anything).Return(common.Address{}, nil)
-		etherman.On("TrustedSequencerURL", mock.Anything).Return("127.0.0.1:8585", nil)
+		etherman.On("TrustedSequencer", mock.Anything).Return(initialAddress, nil)
+		etherman.On("TrustedSequencerURL", mock.Anything).Return(initialURL, nil)
 
 		addressesSubscription := mocks.NewSubscription(t)
 
@@ -66,10 +73,8 @@ func TestTracker(t *testing.T) {
 
 		tracker.Start(ctx)
 
-		var (
-			updatedAddress = common.BytesToAddress([]byte("updated"))
-			updatedURL     = "127.0.0.1:9585"
-		)
+		require.Equal(t, initialAddress, tracker.GetAddr())
+		require.Equal(t, initialURL, tracker.GetUrl())
 
 		eventually(t, 10, func() bool {
 			return addressesChan != nil && urlsChan != nil
@@ -100,8 +105,8 @@ func TestTracker(t *testing.T) {
 
 		etherman := mocks.NewEtherman(t)
 
-		etherman.On("TrustedSequencer", mock.Anything).Return(common.Address{}, nil)
-		etherman.On("TrustedSequencerURL", mock.Anything).Return("127.0.0.1:8585", nil)
+		etherman.On("TrustedSequencer", mock.Anything).Return(initialAddress, nil)
+		etherman.On("TrustedSequencerURL", mock.Anything).Return(initialURL, nil)
 
 		tracker := sequencer.NewTracker(config.L1Config{
 			Timeout:     types.NewDuration(time.Second * 10),
@@ -113,12 +118,10 @@ func TestTracker(t *testing.T) {
 
 		tracker.Start(ctx)
 
-		time.Sleep(time.Second)
+		require.Equal(t, initialAddress, tracker.GetAddr())
+		require.Equal(t, initialURL, tracker.GetUrl())
 
 		tracker.Stop()
-
-		require.Equal(t, common.Address{}, tracker.GetAddr())
-		require.Equal(t, "127.0.0.1:8585", tracker.GetUrl())
 
 		etherman.AssertExpectations(t)
 	})

--- a/services/datacom/datacom_test.go
+++ b/services/datacom/datacom_test.go
@@ -1,6 +1,7 @@
 package datacom
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"errors"
 	"testing"
@@ -41,7 +42,7 @@ func TestDataCom_SignSequence(t *testing.T) {
 	otherPrivateKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	testFn := func(cfg testConfig) {
+	testFn := func(t *testing.T, cfg testConfig) {
 		var (
 			signer         = privateKey
 			signedSequence *types.SignedSequence
@@ -69,10 +70,12 @@ func TestDataCom_SignSequence(t *testing.T) {
 		ethermanMock.On("TrustedSequencer", mock.Anything).Return(crypto.PubkeyToAddress(otherPrivateKey.PublicKey), nil).Once()
 		ethermanMock.On("TrustedSequencerURL", mock.Anything).Return("http://some-url", nil).Once()
 
-		sequencer := sequencer.NewTracker(config.L1Config{
+		sqr := sequencer.NewTracker(config.L1Config{
 			Timeout:     cfgTypes.Duration{Duration: time.Minute},
 			RetryPeriod: cfgTypes.Duration{Duration: time.Second},
 		}, ethermanMock)
+
+		sqr.Start(context.Background())
 
 		if cfg.sender != nil {
 			signedSequence, err = sequence.Sign(cfg.sender)
@@ -88,7 +91,7 @@ func TestDataCom_SignSequence(t *testing.T) {
 			signer = cfg.signer
 		}
 
-		dce := NewEndpoints(dbMock, signer, sequencer)
+		dce := NewEndpoints(dbMock, signer, sqr)
 
 		sig, err := dce.SignSequence(*signedSequence)
 		if cfg.expectedError != "" {
@@ -98,6 +101,8 @@ func TestDataCom_SignSequence(t *testing.T) {
 			require.NotEmpty(t, sig)
 		}
 
+		sqr.Stop()
+
 		txMock.AssertExpectations(t)
 		dbMock.AssertExpectations(t)
 		ethermanMock.AssertExpectations(t)
@@ -106,7 +111,7 @@ func TestDataCom_SignSequence(t *testing.T) {
 	t.Run("Failed to verify sender", func(t *testing.T) {
 		t.Parallel()
 
-		testFn(testConfig{
+		testFn(t, testConfig{
 			expectedError: "failed to verify sender",
 		})
 	})
@@ -114,7 +119,7 @@ func TestDataCom_SignSequence(t *testing.T) {
 	t.Run("Unauthorized sender", func(t *testing.T) {
 		t.Parallel()
 
-		testFn(testConfig{
+		testFn(t, testConfig{
 			sender:        privateKey,
 			expectedError: "unauthorized",
 		})
@@ -123,7 +128,7 @@ func TestDataCom_SignSequence(t *testing.T) {
 	t.Run("Unauthorized sender", func(t *testing.T) {
 		t.Parallel()
 
-		testFn(testConfig{
+		testFn(t, testConfig{
 			sender:        privateKey,
 			expectedError: "unauthorized",
 		})
@@ -132,7 +137,7 @@ func TestDataCom_SignSequence(t *testing.T) {
 	t.Run("Fail to begin state transaction", func(t *testing.T) {
 		t.Parallel()
 
-		testFn(testConfig{
+		testFn(t, testConfig{
 			sender:                       otherPrivateKey,
 			expectedError:                "failed to connect to the state",
 			beginStateTransactionReturns: []interface{}{nil, errors.New("error")},
@@ -142,7 +147,7 @@ func TestDataCom_SignSequence(t *testing.T) {
 	t.Run("Fail to store off chain data - rollback fails", func(t *testing.T) {
 		t.Parallel()
 
-		testFn(testConfig{
+		testFn(t, testConfig{
 			sender:                   otherPrivateKey,
 			expectedError:            "failed to rollback db transaction",
 			storeOffChainDataReturns: []interface{}{errors.New("error")},
@@ -153,7 +158,7 @@ func TestDataCom_SignSequence(t *testing.T) {
 	t.Run("Fail to store off chain data", func(t *testing.T) {
 		t.Parallel()
 
-		testFn(testConfig{
+		testFn(t, testConfig{
 			sender:                   otherPrivateKey,
 			expectedError:            "failed to store offchain data",
 			storeOffChainDataReturns: []interface{}{errors.New("error")},
@@ -164,7 +169,7 @@ func TestDataCom_SignSequence(t *testing.T) {
 	t.Run("Fail to commit tx", func(t *testing.T) {
 		t.Parallel()
 
-		testFn(testConfig{
+		testFn(t, testConfig{
 			sender:                   otherPrivateKey,
 			expectedError:            "failed to commit db transaction",
 			storeOffChainDataReturns: []interface{}{nil},
@@ -180,7 +185,7 @@ func TestDataCom_SignSequence(t *testing.T) {
 
 		key.D = common.Big0 // alter the key so that signing does not pass
 
-		testFn(testConfig{
+		testFn(t, testConfig{
 			sender:                   otherPrivateKey,
 			signer:                   key,
 			storeOffChainDataReturns: []interface{}{nil},
@@ -192,7 +197,7 @@ func TestDataCom_SignSequence(t *testing.T) {
 	t.Run("Happy path - sequence signed", func(t *testing.T) {
 		t.Parallel()
 
-		testFn(testConfig{
+		testFn(t, testConfig{
 			sender:                   otherPrivateKey,
 			storeOffChainDataReturns: []interface{}{nil},
 			commitReturns:            []interface{}{nil},

--- a/services/datacom/datacom_test.go
+++ b/services/datacom/datacom_test.go
@@ -66,14 +66,13 @@ func TestDataCom_SignSequence(t *testing.T) {
 
 		ethermanMock := mocks.NewEtherman(t)
 
-		ethermanMock.On("TrustedSequencer").Return(crypto.PubkeyToAddress(otherPrivateKey.PublicKey), nil).Once()
-		ethermanMock.On("TrustedSequencerURL").Return("http://some-url", nil).Once()
+		ethermanMock.On("TrustedSequencer", mock.Anything).Return(crypto.PubkeyToAddress(otherPrivateKey.PublicKey), nil).Once()
+		ethermanMock.On("TrustedSequencerURL", mock.Anything).Return("http://some-url", nil).Once()
 
-		sequencer, err := sequencer.NewTracker(config.L1Config{
+		sequencer := sequencer.NewTracker(config.L1Config{
 			Timeout:     cfgTypes.Duration{Duration: time.Minute},
 			RetryPeriod: cfgTypes.Duration{Duration: time.Second},
 		}, ethermanMock)
-		require.NoError(t, err)
 
 		if cfg.sender != nil {
 			signedSequence, err = sequence.Sign(cfg.sender)

--- a/test/e2e/sequencer_tracker_test.go
+++ b/test/e2e/sequencer_tracker_test.go
@@ -31,7 +31,7 @@ func TestSequencerAddrExists(t *testing.T) {
 
 	tracker := sequencer.NewTracker(cfg.L1, etm)
 
-	go tracker.Start(ctx.Context)
+	tracker.Start(ctx.Context)
 	defer tracker.Stop()
 
 	addr := tracker.GetAddr()

--- a/test/e2e/sequencer_tracker_test.go
+++ b/test/e2e/sequencer_tracker_test.go
@@ -29,8 +29,7 @@ func TestSequencerAddrExists(t *testing.T) {
 	etm, err := etherman.New(ctx.Context, cfg.L1)
 	require.NoError(t, err)
 
-	tracker, err := sequencer.NewTracker(cfg.L1, etm)
-	require.NoError(t, err)
+	tracker := sequencer.NewTracker(cfg.L1, etm)
 
 	go tracker.Start(ctx.Context)
 	defer tracker.Stop()


### PR DESCRIPTION
Added a maximum number of connection retries to the sequencer tracker. If the number of attempts is exceeded, the app is going to crash.