### PR TITLE
perf: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -236,7 +237,7 @@ func (h *Handler) getFnHandler(req Request) (*serviceData, *funcData, Error) {
 
 func validateFunc(funcName string, fv reflect.Value, isMethod bool) (inNum int, reqt []reflect.Type, err error) {
 	if funcName == "" {
-		err = fmt.Errorf("getBlockNumByArg cannot be empty")
+		err = errors.New("getBlockNumByArg cannot be empty")
 		return
 	}
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -54,7 +54,7 @@ func (s *Server) Start() error {
 // startHTTP starts a server to respond http requests
 func (s *Server) startHTTP() error {
 	if s.srv != nil {
-		return fmt.Errorf("server already started")
+		return errors.New("server already started")
 	}
 
 	address := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)

--- a/test/operations/operations.go
+++ b/test/operations/operations.go
@@ -62,7 +62,7 @@ const (
 var (
 	// ErrTimeoutReached is thrown when the timeout is reached and
 	// because the condition is not matched
-	ErrTimeoutReached = fmt.Errorf("timeout has been reached")
+	ErrTimeoutReached = errors.New("timeout has been reached")
 )
 
 // Poll retries the given condition with the given interval until it succeeds

--- a/types/types.go
+++ b/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -103,7 +104,7 @@ type ArgHash common.Hash
 // UnmarshalText unmarshals from text
 func (arg *ArgHash) UnmarshalText(input []byte) error {
 	if !IsHexValid(string(input)) {
-		return fmt.Errorf("invalid hash, it needs to be a hexadecimal value")
+		return errors.New("invalid hash, it needs to be a hexadecimal value")
 	}
 
 	str := strings.TrimPrefix(string(input), "0x")


### PR DESCRIPTION
If you don't need to format the string, recommended to use error.New().