### PR TITLE
Include version info in the logs at the app startup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,8 +75,7 @@ func start(cliCtx *cli.Context) error {
 	}
 	setupLog(c.Log)
 
-	dataavailability.PrintVersion(os.Stdout)
-	log.Info("Starting application...")
+	log.Infof("Starting application...\n%s", dataavailability.GetVersionInfo())
 
 	// Prepare DB
 	pg, err := db.InitContext(cliCtx.Context, c.DB)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,6 +75,9 @@ func start(cliCtx *cli.Context) error {
 	}
 	setupLog(c.Log)
 
+	dataavailability.PrintVersion(os.Stdout)
+	log.Info("Starting application...")
+
 	// Prepare DB
 	pg, err := db.InitContext(cliCtx.Context, c.DB)
 	if err != nil {

--- a/version.go
+++ b/version.go
@@ -16,10 +16,16 @@ var (
 
 // PrintVersion prints version info into the provided io.Writer.
 func PrintVersion(w io.Writer) {
-	fmt.Fprintf(w, "Version:      %s\n", Version)
-	fmt.Fprintf(w, "Git revision: %s\n", GitRev)
-	fmt.Fprintf(w, "Git branch:   %s\n", GitBranch)
-	fmt.Fprintf(w, "Go version:   %s\n", runtime.Version())
-	fmt.Fprintf(w, "Built:        %s\n", BuildDate)
-	fmt.Fprintf(w, "OS/Arch:      %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Fprint(w, GetVersionInfo())
+}
+
+// GetVersionInfo returns version information as a formatted string.
+func GetVersionInfo() string {
+	versionInfo := fmt.Sprintf("Version:      %s\n", Version)
+	versionInfo += fmt.Sprintf("Git revision: %s\n", GitRev)
+	versionInfo += fmt.Sprintf("Git branch:   %s\n", GitBranch)
+	versionInfo += fmt.Sprintf("Go version:   %s\n", runtime.Version())
+	versionInfo += fmt.Sprintf("Built:        %s\n", BuildDate)
+	versionInfo += fmt.Sprintf("OS/Arch:      %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	return versionInfo
 }


### PR DESCRIPTION
The PR introduces version metadata information dump at the app startup.

For example:
```go
Starting application...
Version:      v0.0.7-19-gf9a61b2
Git revision: f9a61b2
Git branch:   feat/include-version-info-to-logs
Go version:   go1.19.13
Built:        Sun, 28 Apr 2024 09:02:03 +0000
OS/Arch:      linux/amd64
```