### PR TITLE
[Audit remediation] Issue B: Race Condition Between FilterSequenceBatches and handleReorgs

### DIFF
--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -39,7 +39,7 @@ type BatchSynchronizer struct {
 	self             common.Address
 	db               db.DB
 	committee        map[common.Address]etherman.DataCommitteeMember
-	comiteeLock      sync.Mutex
+	comitteeLock     sync.Mutex
 	syncLock         sync.Mutex
 	reorgs           <-chan BlockReorg
 	sequencer        SequencerTracker
@@ -76,8 +76,8 @@ func NewBatchSynchronizer(
 }
 
 func (bs *BatchSynchronizer) resolveCommittee() error {
-	bs.comiteeLock.Lock()
-	defer bs.comiteeLock.Unlock()
+	bs.comitteeLock.Lock()
+	defer bs.comitteeLock.Unlock()
 
 	committee := make(map[common.Address]etherman.DataCommitteeMember)
 	current, err := bs.client.GetCurrentDataCommittee()

--- a/test/e2e/datacommittee_test.go
+++ b/test/e2e/datacommittee_test.go
@@ -193,7 +193,7 @@ func TestDataCommittee(t *testing.T) {
 
 	// allow the member to startup and synchronize
 	log.Infof("waiting for delayed member %d to synchronize...", delayedMember.i)
-	<-time.After(20 * time.Second)
+	<-time.After(90 * time.Second)
 
 	iter, err := getSequenceBatchesEventIterator(clientL1)
 	require.NoError(t, err)

--- a/test/e2e/datacommittee_test.go
+++ b/test/e2e/datacommittee_test.go
@@ -193,7 +193,7 @@ func TestDataCommittee(t *testing.T) {
 
 	// allow the member to startup and synchronize
 	log.Infof("waiting for delayed member %d to synchronize...", delayedMember.i)
-	<-time.After(90 * time.Second)
+	<-time.After(20 * time.Second)
 
 	iter, err := getSequenceBatchesEventIterator(clientL1)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR fixes the issue found by audit, where a race condition can happen while handling reorgs in the `batchSyncronizer` when a new sequence of batches is being synced.

Since both routines update the start block from which we sync batches, it may happen that reorg detector will update the start block while the sync routine is downloading batches, which can lead to some inconsistent batches.

PR introduces a `sync` lock which both routines will use, meaning, we will not handle reorg until we finish syncing batches, or we will not sync batches, until we handle a reorg first.