### PR TITLE
Introduce thread-safe committee map to the `synchronizer`

### DIFF
--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -80,13 +80,13 @@ func (bs *BatchSynchronizer) resolveCommittee() error {
 		return err
 	}
 
-	bs.committee = NewCommitteeMapSafe()
 	filteredMembers := make([]etherman.DataCommitteeMember, 0, len(current.Members))
 	for _, m := range current.Members {
 		if m.Addr != bs.self {
 			filteredMembers = append(filteredMembers, m)
 		}
 	}
+	bs.committee = NewCommitteeMapSafe()
 	bs.committee.StoreBatch(filteredMembers)
 	return nil
 }

--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -325,8 +325,8 @@ func (bs *BatchSynchronizer) resolve(batch types.BatchKey) (*types.OffChainData,
 
 	// pull out the members, iterating will change the map on error
 	members := make([]etherman.DataCommitteeMember, bs.committee.Length())
-	bs.committee.Range(func(key common.Address, value etherman.DataCommitteeMember) bool {
-		members = append(members, value)
+	bs.committee.Range(func(_ common.Address, member etherman.DataCommitteeMember) bool {
+		members = append(members, member)
 		return true
 	})
 

--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -86,6 +86,7 @@ func (bs *BatchSynchronizer) resolveCommittee() error {
 			filteredMembers = append(filteredMembers, m)
 		}
 	}
+
 	bs.committee = NewCommitteeMapSafe()
 	bs.committee.StoreBatch(filteredMembers)
 	return nil
@@ -324,11 +325,7 @@ func (bs *BatchSynchronizer) resolve(batch types.BatchKey) (*types.OffChainData,
 	}
 
 	// pull out the members, iterating will change the map on error
-	members := make([]etherman.DataCommitteeMember, bs.committee.Length())
-	bs.committee.Range(func(_ common.Address, member etherman.DataCommitteeMember) bool {
-		members = append(members, member)
-		return true
-	})
+	members := bs.committee.AsSlice()
 
 	// iterate through them randomly until data is resolved
 	for _, r := range rand.Perm(len(members)) {

--- a/synchronizer/batches_test.go
+++ b/synchronizer/batches_test.go
@@ -67,7 +67,7 @@ func TestBatchSynchronizer_ResolveCommittee(t *testing.T) {
 		}
 
 		require.NoError(t, batchSyncronizer.resolveCommittee())
-		require.Len(t, batchSyncronizer.committee, len(committee.Members))
+		require.Equal(t, len(committee.Members), batchSyncronizer.committee.Length())
 
 		ethermanMock.AssertExpectations(t)
 	})
@@ -130,6 +130,7 @@ func TestBatchSynchronizer_Resolve(t *testing.T) {
 			client:           ethermanMock,
 			sequencer:        sequencerMock,
 			rpcClientFactory: clientFactoryMock,
+			committee:        NewCommitteeMapSafe(),
 		}
 
 		offChainData, err := batchSyncronizer.resolve(batchKey)

--- a/synchronizer/committee_map.go
+++ b/synchronizer/committee_map.go
@@ -2,76 +2,69 @@ package synchronizer
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/0xPolygon/cdk-data-availability/etherman"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// CommitteeMapSafe represents a thread-safe implementation for the data availability committee members map
+// CommitteeMapSafe represents a thread-safe implementation for the data availability committee members map.
 type CommitteeMapSafe struct {
-	mu sync.RWMutex
-
-	members map[common.Address]etherman.DataCommitteeMember
+	members      sync.Map
+	membersCount int32
 }
 
 // NewCommitteeMapSafe creates a new CommitteeMapSafe.
 func NewCommitteeMapSafe() *CommitteeMapSafe {
-	return &CommitteeMapSafe{
-		members: make(map[common.Address]etherman.DataCommitteeMember),
-	}
+	return &CommitteeMapSafe{members: sync.Map{}}
 }
 
 // Store sets the value for a key.
-func (t *CommitteeMapSafe) Store(key common.Address, value etherman.DataCommitteeMember) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.members[key] = value
+func (t *CommitteeMapSafe) Store(member etherman.DataCommitteeMember) {
+	_, exists := t.members.LoadOrStore(member.Addr, member)
+	if !exists {
+		atomic.AddInt32(&t.membersCount, 1)
+	} else {
+		t.members.Store(member.Addr, member)
+	}
 }
 
 // StoreBatch sets the range of values and keys.
 func (t *CommitteeMapSafe) StoreBatch(members []etherman.DataCommitteeMember) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	for _, m := range members {
-		t.members[m.Addr] = m
+		t.Store(m)
 	}
 }
 
 // Load returns the value stored in the map for a key, or false if no value is present.
-func (t *CommitteeMapSafe) Load(key common.Address) (etherman.DataCommitteeMember, bool) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	value, ok := t.members[key]
-	return value, ok
+func (t *CommitteeMapSafe) Load(addr common.Address) (etherman.DataCommitteeMember, bool) {
+	rawValue, exists := t.members.Load(addr)
+	if !exists {
+		return etherman.DataCommitteeMember{}, false
+	}
+	return rawValue.(etherman.DataCommitteeMember), exists
 }
 
 // Delete deletes the value for a key.
 func (t *CommitteeMapSafe) Delete(key common.Address) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	delete(t.members, key)
+	_, exists := t.members.LoadAndDelete(key)
+	if exists {
+		atomic.AddInt32(&t.membersCount, -1)
+	}
 }
 
-// AsSlice returns a slice of data committee members.
+// AsSlice returns a slice of etherman.DataCommitteeMembers.
 func (t *CommitteeMapSafe) AsSlice() []etherman.DataCommitteeMember {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
+	membersSlice := make([]etherman.DataCommitteeMember, 0, atomic.LoadInt32(&t.membersCount))
+	t.members.Range(func(_, rawMember any) bool {
+		membersSlice = append(membersSlice, rawMember.(etherman.DataCommitteeMember))
 
-	membersSlice := make([]etherman.DataCommitteeMember, 0, len(t.members))
-	for _, m := range t.members {
-		membersSlice = append(membersSlice, m)
-	}
+		return true
+	})
 	return membersSlice
 }
 
 // Length returns the current length of the map.
 func (t *CommitteeMapSafe) Length() int {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	return len(t.members)
+	return int(atomic.LoadInt32(&t.membersCount))
 }

--- a/synchronizer/committee_map.go
+++ b/synchronizer/committee_map.go
@@ -1,0 +1,78 @@
+package synchronizer
+
+import (
+	"sync"
+
+	"github.com/0xPolygon/cdk-data-availability/etherman"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// CommitteeMapSafe represents a thread-safe implementation for the data availability committee members map
+type CommitteeMapSafe struct {
+	mu sync.RWMutex
+
+	members map[common.Address]etherman.DataCommitteeMember
+}
+
+// NewCommitteeMapSafe creates a new CommitteeMapSafe.
+func NewCommitteeMapSafe() *CommitteeMapSafe {
+	return &CommitteeMapSafe{
+		members: make(map[common.Address]etherman.DataCommitteeMember),
+	}
+}
+
+// Store sets the value for a key.
+func (t *CommitteeMapSafe) Store(key common.Address, value etherman.DataCommitteeMember) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.members[key] = value
+}
+
+// StoreBatch sets the range of values and keys.
+func (t *CommitteeMapSafe) StoreBatch(members []etherman.DataCommitteeMember) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for _, m := range members {
+		t.members[m.Addr] = m
+	}
+}
+
+// Load returns the value stored in the map for a key, or false if no value is present.
+func (t *CommitteeMapSafe) Load(key common.Address) (etherman.DataCommitteeMember, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	value, ok := t.members[key]
+	return value, ok
+}
+
+// Delete deletes the value for a key.
+func (t *CommitteeMapSafe) Delete(key common.Address) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	delete(t.members, key)
+}
+
+// Range calls f sequentially for each key and value present in the map.
+// If f returns false, range stops the iteration.
+func (t *CommitteeMapSafe) Range(f func(key common.Address, value etherman.DataCommitteeMember) bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	for k, v := range t.members {
+		if !f(k, v) {
+			break
+		}
+	}
+}
+
+// Length returns the current length of the map.
+func (t *CommitteeMapSafe) Length() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return len(t.members)
+}

--- a/synchronizer/committee_map.go
+++ b/synchronizer/committee_map.go
@@ -56,17 +56,16 @@ func (t *CommitteeMapSafe) Delete(key common.Address) {
 	delete(t.members, key)
 }
 
-// Range calls f sequentially for each key and value present in the map.
-// If f returns false, range stops the iteration.
-func (t *CommitteeMapSafe) Range(f func(key common.Address, value etherman.DataCommitteeMember) bool) {
+// AsSlice returns a slice of data committee members.
+func (t *CommitteeMapSafe) AsSlice() []etherman.DataCommitteeMember {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
-	for k, v := range t.members {
-		if !f(k, v) {
-			break
-		}
+	membersSlice := make([]etherman.DataCommitteeMember, 0, len(t.members))
+	for _, m := range t.members {
+		membersSlice = append(membersSlice, m)
 	}
+	return membersSlice
 }
 
 // Length returns the current length of the map.

--- a/synchronizer/committee_map_test.go
+++ b/synchronizer/committee_map_test.go
@@ -67,41 +67,35 @@ func TestStoreBatch(t *testing.T) {
 	}
 }
 
-func TestRange(t *testing.T) {
+func TestAsSlice(t *testing.T) {
 	committee := NewCommitteeMapSafe()
+	committee.StoreBatch(
+		[]etherman.DataCommitteeMember{
+			{Addr: common.HexToAddress("0x1"), URL: "Member 1"},
+			{Addr: common.HexToAddress("0x2"), URL: "Member 2"},
+			{Addr: common.HexToAddress("0x3"), URL: "Member 3"},
+			{Addr: common.HexToAddress("0x4"), URL: "Member 4"},
+		})
 
-	members := []etherman.DataCommitteeMember{
-		{Addr: common.HexToAddress("0x1"), URL: "Member 1"},
-		{Addr: common.HexToAddress("0x2"), URL: "Member 2"},
-		{Addr: common.HexToAddress("0x3"), URL: "Member 3"},
-	}
+	membersSlice := committee.AsSlice()
 
-	committee.StoreBatch(members)
-
-	foundMembers := make(map[common.Address]etherman.DataCommitteeMember)
-	committee.Range(func(key common.Address, value etherman.DataCommitteeMember) bool {
-		foundMembers[key] = value
-		return true
-	})
-
-	require.Equal(t, len(members), len(foundMembers))
-	for _, member := range members {
-		require.Equal(t, member, foundMembers[member.Addr])
+	require.Equal(t, committee.Length(), len(membersSlice))
+	for _, member := range membersSlice {
+		foundMember, ok := committee.Load(member.Addr)
+		require.True(t, ok)
+		require.Equal(t, foundMember, member)
 	}
 }
 
-// Test for Length method
 func TestLength(t *testing.T) {
 	committee := NewCommitteeMapSafe()
 
 	members := []etherman.DataCommitteeMember{
 		{Addr: common.HexToAddress("0x1"), URL: "http://localhost:1001"},
 		{Addr: common.HexToAddress("0x2"), URL: "http://localhost:1002"},
-		{Addr: common.HexToAddress("0x3"), URL: "http://localhost:1003"},
 	}
 
 	committee.StoreBatch(members)
 
-	length := committee.Length()
-	require.Equal(t, len(members), length)
+	require.Equal(t, len(members), committee.Length())
 }

--- a/synchronizer/committee_map_test.go
+++ b/synchronizer/committee_map_test.go
@@ -1,0 +1,107 @@
+package synchronizer
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/0xPolygon/cdk-data-availability/etherman"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreAndLoad(t *testing.T) {
+	committee := NewCommitteeMapSafe()
+
+	member := etherman.DataCommitteeMember{Addr: common.HexToAddress("0x1"), URL: "Member 1"}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		committee.Store(member.Addr, member)
+	}()
+
+	wg.Wait()
+
+	loadedMember, ok := committee.Load(member.Addr)
+	require.True(t, ok)
+	require.Equal(t, member, loadedMember)
+}
+
+func TestDelete(t *testing.T) {
+	committee := NewCommitteeMapSafe()
+
+	member := etherman.DataCommitteeMember{Addr: common.HexToAddress("0x1"), URL: "Member 1"}
+
+	committee.Store(member.Addr, member)
+	committee.Delete(member.Addr)
+
+	_, ok := committee.Load(member.Addr)
+	require.False(t, ok)
+}
+
+func TestStoreBatch(t *testing.T) {
+	committee := NewCommitteeMapSafe()
+
+	members := []etherman.DataCommitteeMember{
+		{Addr: common.HexToAddress("0x1"), URL: "http://localhost:1001"},
+		{Addr: common.HexToAddress("0x2"), URL: "http://localhost:1002"},
+		{Addr: common.HexToAddress("0x3"), URL: "http://localhost:1003"},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		committee.StoreBatch(members)
+	}()
+
+	wg.Wait()
+
+	for _, member := range members {
+		loadedMember, ok := committee.Load(member.Addr)
+		require.True(t, ok)
+		require.Equal(t, member, loadedMember)
+	}
+}
+
+func TestRange(t *testing.T) {
+	committee := NewCommitteeMapSafe()
+
+	members := []etherman.DataCommitteeMember{
+		{Addr: common.HexToAddress("0x1"), URL: "Member 1"},
+		{Addr: common.HexToAddress("0x2"), URL: "Member 2"},
+		{Addr: common.HexToAddress("0x3"), URL: "Member 3"},
+	}
+
+	committee.StoreBatch(members)
+
+	foundMembers := make(map[common.Address]etherman.DataCommitteeMember)
+	committee.Range(func(key common.Address, value etherman.DataCommitteeMember) bool {
+		foundMembers[key] = value
+		return true
+	})
+
+	require.Equal(t, len(members), len(foundMembers))
+	for _, member := range members {
+		require.Equal(t, member, foundMembers[member.Addr])
+	}
+}
+
+// Test for Length method
+func TestLength(t *testing.T) {
+	committee := NewCommitteeMapSafe()
+
+	members := []etherman.DataCommitteeMember{
+		{Addr: common.HexToAddress("0x1"), URL: "http://localhost:1001"},
+		{Addr: common.HexToAddress("0x2"), URL: "http://localhost:1002"},
+		{Addr: common.HexToAddress("0x3"), URL: "http://localhost:1003"},
+	}
+
+	committee.StoreBatch(members)
+
+	length := committee.Length()
+	require.Equal(t, len(members), length)
+}


### PR DESCRIPTION
This PR is continuation of #94 and it introduces thread-safe wrapper around the committee members map, allowing for thread-safe manipulation.