### PR TITLE
[Audit remediation] Suggestion 1: Adopt a Verifiable Database / Batch Format

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -56,7 +56,7 @@ func Test_DB_StoreLastProcessedBlock(t *testing.T) {
 
 			dbPG := New(wdb)
 
-			err = dbPG.StoreLastProcessedBlock(context.Background(), tt.task, tt.block)
+			err = dbPG.StoreLastProcessedBlock(context.Background(), tt.block, tt.task)
 			if tt.returnErr != nil {
 				require.ErrorIs(t, err, tt.returnErr)
 			} else {
@@ -116,7 +116,7 @@ func Test_DB_GetLastProcessedBlock(t *testing.T) {
 
 			dbPG := New(wdb)
 
-			err = dbPG.StoreLastProcessedBlock(context.Background(), tt.task, tt.block)
+			err = dbPG.StoreLastProcessedBlock(context.Background(), tt.block, tt.task)
 			require.NoError(t, err)
 
 			actual, err := dbPG.GetLastProcessedBlock(context.Background(), tt.task)

--- a/db/migrations/0005.sql
+++ b/db/migrations/0005.sql
@@ -1,10 +1,9 @@
 -- +migrate Down
 ALTER TABLE data_node.offchain_data DROP COLUMN IF EXISTS batch_num;
 
-DELETE FROM data_node.sync_tasks WHERE task = 'L1_BATCH_NUM';
-
 -- +migrate Up
-INSERT INTO data_node.sync_tasks (task, block) VALUES ('L1_BATCH_NUM', 0);
-
 ALTER TABLE data_node.offchain_data
     ADD COLUMN IF NOT EXISTS batch_num BIGINT NOT NULL DEFAULT 0;
+
+-- It triggers resync with an updated logic of all batches
+UPDATE data_node.sync_tasks SET block = 0 WHERE task = 'L1';

--- a/db/migrations/0005.sql
+++ b/db/migrations/0005.sql
@@ -1,0 +1,10 @@
+-- +migrate Down
+ALTER TABLE data_node.offchain_data DROP COLUMN IF EXISTS batch_num;
+
+DELETE FROM data_node.sync_tasks WHERE task = 'L1_BATCH_NUM';
+
+-- +migrate Up
+INSERT INTO data_node.sync_tasks (task, block) VALUES ('L1_BATCH_NUM', 0);
+
+ALTER TABLE data_node.offchain_data
+    ADD COLUMN IF NOT EXISTS batch_num BIGINT NOT NULL DEFAULT 0;

--- a/mocks/db.generated.go
+++ b/mocks/db.generated.go
@@ -128,53 +128,6 @@ func (_c *DB_DeleteUnresolvedBatchKeys_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
-// Exists provides a mock function with given fields: ctx, key
-func (_m *DB) Exists(ctx context.Context, key common.Hash) bool {
-	ret := _m.Called(ctx, key)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Exists")
-	}
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(context.Context, common.Hash) bool); ok {
-		r0 = rf(ctx, key)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// DB_Exists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Exists'
-type DB_Exists_Call struct {
-	*mock.Call
-}
-
-// Exists is a helper method to define mock.On call
-//   - ctx context.Context
-//   - key common.Hash
-func (_e *DB_Expecter) Exists(ctx interface{}, key interface{}) *DB_Exists_Call {
-	return &DB_Exists_Call{Call: _e.mock.On("Exists", ctx, key)}
-}
-
-func (_c *DB_Exists_Call) Run(run func(ctx context.Context, key common.Hash)) *DB_Exists_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(common.Hash))
-	})
-	return _c
-}
-
-func (_c *DB_Exists_Call) Return(_a0 bool) *DB_Exists_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *DB_Exists_Call) RunAndReturn(run func(context.Context, common.Hash) bool) *DB_Exists_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetLastProcessedBlock provides a mock function with given fields: ctx, task
 func (_m *DB) GetLastProcessedBlock(ctx context.Context, task string) (uint64, error) {
 	ret := _m.Called(ctx, task)
@@ -233,23 +186,23 @@ func (_c *DB_GetLastProcessedBlock_Call) RunAndReturn(run func(context.Context, 
 }
 
 // GetOffChainData provides a mock function with given fields: ctx, key
-func (_m *DB) GetOffChainData(ctx context.Context, key common.Hash) (types.ArgBytes, error) {
+func (_m *DB) GetOffChainData(ctx context.Context, key common.Hash) (*types.OffChainData, error) {
 	ret := _m.Called(ctx, key)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOffChainData")
 	}
 
-	var r0 types.ArgBytes
+	var r0 *types.OffChainData
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, common.Hash) (types.ArgBytes, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, common.Hash) (*types.OffChainData, error)); ok {
 		return rf(ctx, key)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, common.Hash) types.ArgBytes); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, common.Hash) *types.OffChainData); ok {
 		r0 = rf(ctx, key)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(types.ArgBytes)
+			r0 = ret.Get(0).(*types.OffChainData)
 		}
 	}
 
@@ -281,12 +234,12 @@ func (_c *DB_GetOffChainData_Call) Run(run func(ctx context.Context, key common.
 	return _c
 }
 
-func (_c *DB_GetOffChainData_Call) Return(_a0 types.ArgBytes, _a1 error) *DB_GetOffChainData_Call {
+func (_c *DB_GetOffChainData_Call) Return(_a0 *types.OffChainData, _a1 error) *DB_GetOffChainData_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *DB_GetOffChainData_Call) RunAndReturn(run func(context.Context, common.Hash) (types.ArgBytes, error)) *DB_GetOffChainData_Call {
+func (_c *DB_GetOffChainData_Call) RunAndReturn(run func(context.Context, common.Hash) (*types.OffChainData, error)) *DB_GetOffChainData_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -351,23 +304,23 @@ func (_c *DB_GetUnresolvedBatchKeys_Call) RunAndReturn(run func(context.Context,
 }
 
 // ListOffChainData provides a mock function with given fields: ctx, keys
-func (_m *DB) ListOffChainData(ctx context.Context, keys []common.Hash) (map[common.Hash]types.ArgBytes, error) {
+func (_m *DB) ListOffChainData(ctx context.Context, keys []common.Hash) ([]types.OffChainData, error) {
 	ret := _m.Called(ctx, keys)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListOffChainData")
 	}
 
-	var r0 map[common.Hash]types.ArgBytes
+	var r0 []types.OffChainData
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []common.Hash) (map[common.Hash]types.ArgBytes, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []common.Hash) ([]types.OffChainData, error)); ok {
 		return rf(ctx, keys)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []common.Hash) map[common.Hash]types.ArgBytes); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []common.Hash) []types.OffChainData); ok {
 		r0 = rf(ctx, keys)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[common.Hash]types.ArgBytes)
+			r0 = ret.Get(0).([]types.OffChainData)
 		}
 	}
 
@@ -399,12 +352,12 @@ func (_c *DB_ListOffChainData_Call) Run(run func(ctx context.Context, keys []com
 	return _c
 }
 
-func (_c *DB_ListOffChainData_Call) Return(_a0 map[common.Hash]types.ArgBytes, _a1 error) *DB_ListOffChainData_Call {
+func (_c *DB_ListOffChainData_Call) Return(_a0 []types.OffChainData, _a1 error) *DB_ListOffChainData_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *DB_ListOffChainData_Call) RunAndReturn(run func(context.Context, []common.Hash) (map[common.Hash]types.ArgBytes, error)) *DB_ListOffChainData_Call {
+func (_c *DB_ListOffChainData_Call) RunAndReturn(run func(context.Context, []common.Hash) ([]types.OffChainData, error)) *DB_ListOffChainData_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/db.generated.go
+++ b/mocks/db.generated.go
@@ -409,17 +409,17 @@ func (_c *DB_ListOffChainData_Call) RunAndReturn(run func(context.Context, []com
 	return _c
 }
 
-// StoreLastProcessedBlock provides a mock function with given fields: ctx, task, block
-func (_m *DB) StoreLastProcessedBlock(ctx context.Context, task string, block uint64) error {
-	ret := _m.Called(ctx, task, block)
+// StoreLastProcessedBlock provides a mock function with given fields: ctx, block, task
+func (_m *DB) StoreLastProcessedBlock(ctx context.Context, block uint64, task string) error {
+	ret := _m.Called(ctx, block, task)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StoreLastProcessedBlock")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, uint64) error); ok {
-		r0 = rf(ctx, task, block)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, string) error); ok {
+		r0 = rf(ctx, block, task)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -434,15 +434,15 @@ type DB_StoreLastProcessedBlock_Call struct {
 
 // StoreLastProcessedBlock is a helper method to define mock.On call
 //   - ctx context.Context
-//   - task string
 //   - block uint64
-func (_e *DB_Expecter) StoreLastProcessedBlock(ctx interface{}, task interface{}, block interface{}) *DB_StoreLastProcessedBlock_Call {
-	return &DB_StoreLastProcessedBlock_Call{Call: _e.mock.On("StoreLastProcessedBlock", ctx, task, block)}
+//   - task string
+func (_e *DB_Expecter) StoreLastProcessedBlock(ctx interface{}, block interface{}, task interface{}) *DB_StoreLastProcessedBlock_Call {
+	return &DB_StoreLastProcessedBlock_Call{Call: _e.mock.On("StoreLastProcessedBlock", ctx, block, task)}
 }
 
-func (_c *DB_StoreLastProcessedBlock_Call) Run(run func(ctx context.Context, task string, block uint64)) *DB_StoreLastProcessedBlock_Call {
+func (_c *DB_StoreLastProcessedBlock_Call) Run(run func(ctx context.Context, block uint64, task string)) *DB_StoreLastProcessedBlock_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(uint64))
+		run(args[0].(context.Context), args[1].(uint64), args[2].(string))
 	})
 	return _c
 }
@@ -452,7 +452,7 @@ func (_c *DB_StoreLastProcessedBlock_Call) Return(_a0 error) *DB_StoreLastProces
 	return _c
 }
 
-func (_c *DB_StoreLastProcessedBlock_Call) RunAndReturn(run func(context.Context, string, uint64) error) *DB_StoreLastProcessedBlock_Call {
+func (_c *DB_StoreLastProcessedBlock_Call) RunAndReturn(run func(context.Context, uint64, string) error) *DB_StoreLastProcessedBlock_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/sequencer_tracker.generated.go
+++ b/mocks/sequencer_tracker.generated.go
@@ -3,6 +3,8 @@
 package mocks
 
 import (
+	context "context"
+
 	sequencer "github.com/0xPolygon/cdk-data-availability/sequencer"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -20,9 +22,9 @@ func (_m *SequencerTracker) EXPECT() *SequencerTracker_Expecter {
 	return &SequencerTracker_Expecter{mock: &_m.Mock}
 }
 
-// GetSequenceBatch provides a mock function with given fields: batchNum
-func (_m *SequencerTracker) GetSequenceBatch(batchNum uint64) (*sequencer.SeqBatch, error) {
-	ret := _m.Called(batchNum)
+// GetSequenceBatch provides a mock function with given fields: ctx, batchNum
+func (_m *SequencerTracker) GetSequenceBatch(ctx context.Context, batchNum uint64) (*sequencer.SeqBatch, error) {
+	ret := _m.Called(ctx, batchNum)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetSequenceBatch")
@@ -30,19 +32,19 @@ func (_m *SequencerTracker) GetSequenceBatch(batchNum uint64) (*sequencer.SeqBat
 
 	var r0 *sequencer.SeqBatch
 	var r1 error
-	if rf, ok := ret.Get(0).(func(uint64) (*sequencer.SeqBatch, error)); ok {
-		return rf(batchNum)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64) (*sequencer.SeqBatch, error)); ok {
+		return rf(ctx, batchNum)
 	}
-	if rf, ok := ret.Get(0).(func(uint64) *sequencer.SeqBatch); ok {
-		r0 = rf(batchNum)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64) *sequencer.SeqBatch); ok {
+		r0 = rf(ctx, batchNum)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*sequencer.SeqBatch)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(uint64) error); ok {
-		r1 = rf(batchNum)
+	if rf, ok := ret.Get(1).(func(context.Context, uint64) error); ok {
+		r1 = rf(ctx, batchNum)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -56,14 +58,15 @@ type SequencerTracker_GetSequenceBatch_Call struct {
 }
 
 // GetSequenceBatch is a helper method to define mock.On call
+//   - ctx context.Context
 //   - batchNum uint64
-func (_e *SequencerTracker_Expecter) GetSequenceBatch(batchNum interface{}) *SequencerTracker_GetSequenceBatch_Call {
-	return &SequencerTracker_GetSequenceBatch_Call{Call: _e.mock.On("GetSequenceBatch", batchNum)}
+func (_e *SequencerTracker_Expecter) GetSequenceBatch(ctx interface{}, batchNum interface{}) *SequencerTracker_GetSequenceBatch_Call {
+	return &SequencerTracker_GetSequenceBatch_Call{Call: _e.mock.On("GetSequenceBatch", ctx, batchNum)}
 }
 
-func (_c *SequencerTracker_GetSequenceBatch_Call) Run(run func(batchNum uint64)) *SequencerTracker_GetSequenceBatch_Call {
+func (_c *SequencerTracker_GetSequenceBatch_Call) Run(run func(ctx context.Context, batchNum uint64)) *SequencerTracker_GetSequenceBatch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(uint64))
+		run(args[0].(context.Context), args[1].(uint64))
 	})
 	return _c
 }
@@ -73,7 +76,7 @@ func (_c *SequencerTracker_GetSequenceBatch_Call) Return(_a0 *sequencer.SeqBatch
 	return _c
 }
 
-func (_c *SequencerTracker_GetSequenceBatch_Call) RunAndReturn(run func(uint64) (*sequencer.SeqBatch, error)) *SequencerTracker_GetSequenceBatch_Call {
+func (_c *SequencerTracker_GetSequenceBatch_Call) RunAndReturn(run func(context.Context, uint64) (*sequencer.SeqBatch, error)) *SequencerTracker_GetSequenceBatch_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/sequencer/call.go
+++ b/sequencer/call.go
@@ -1,6 +1,7 @@
 package sequencer
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -17,8 +18,8 @@ type SeqBatch struct {
 }
 
 // GetData returns batch data from the trusted sequencer
-func GetData(url string, batchNum uint64) (*SeqBatch, error) {
-	response, err := rpc.JSONRPCCall(url, "zkevm_getBatchByNumber", batchNum, true)
+func GetData(ctx context.Context, url string, batchNum uint64) (*SeqBatch, error) {
+	response, err := rpc.JSONRPCCallWithContext(ctx, url, "zkevm_getBatchByNumber", batchNum, true)
 	if err != nil {
 		return nil, err
 	}

--- a/sequencer/call_test.go
+++ b/sequencer/call_test.go
@@ -1,6 +1,7 @@
 package sequencer
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -82,7 +83,7 @@ func Test_GetData(t *testing.T) {
 			}))
 			defer svr.Close()
 
-			got, err := GetData(svr.URL, tt.batchNum)
+			got, err := GetData(context.Background(), svr.URL, tt.batchNum)
 			if tt.err != nil {
 				require.Error(t, err)
 				require.EqualError(t, tt.err, err.Error())

--- a/sequencer/tracker.go
+++ b/sequencer/tracker.go
@@ -302,8 +302,8 @@ func (st *Tracker) pollUrlChanges(ctx context.Context, urlChan chan<- string) {
 }
 
 // GetSequenceBatch returns sequence batch for given batch number
-func (st *Tracker) GetSequenceBatch(batchNum uint64) (*SeqBatch, error) {
-	return GetData(st.GetUrl(), batchNum)
+func (st *Tracker) GetSequenceBatch(ctx context.Context, batchNum uint64) (*SeqBatch, error) {
+	return GetData(ctx, st.GetUrl(), batchNum)
 }
 
 // Stop stops the SequencerTracker

--- a/services/status/status.go
+++ b/services/status/status.go
@@ -39,7 +39,7 @@ func (s *Endpoints) GetStatus() (interface{}, rpc.Error) {
 		log.Errorf("failed to get the key count from the offchain_data table: %v", err)
 	}
 
-	backfillProgress, err := s.db.GetLastProcessedBlock(ctx, synchronizer.L1SyncTask)
+	backfillProgress, err := s.db.GetLastProcessedBlock(ctx, string(synchronizer.L1SyncTask))
 	if err != nil {
 		log.Errorf("failed to get last block processed by the synchronizer: %v", err)
 	}

--- a/services/sync/sync.go
+++ b/services/sync/sync.go
@@ -38,7 +38,7 @@ func (z *Endpoints) GetOffChainData(hash types.ArgHash) (interface{}, rpc.Error)
 		return "0x0", rpc.NewRPCError(rpc.DefaultErrorCode, "failed to get the requested data")
 	}
 
-	return data, nil
+	return types.ArgBytes(data.Value), nil
 }
 
 // ListOffChainData returns the list of images of the given hashes
@@ -59,5 +59,10 @@ func (z *Endpoints) ListOffChainData(hashes []types.ArgHash) (interface{}, rpc.E
 		return "0x0", rpc.NewRPCError(rpc.DefaultErrorCode, "failed to list the requested data")
 	}
 
-	return list, nil
+	listMap := make(map[common.Hash]types.ArgBytes)
+	for _, data := range list {
+		listMap[data.Key] = data.Value
+	}
+
+	return listMap, nil
 }

--- a/services/sync/sync_test.go
+++ b/services/sync/sync_test.go
@@ -15,19 +15,27 @@ func TestEndpoints_GetOffChainData(t *testing.T) {
 	tests := []struct {
 		name  string
 		hash  types.ArgHash
-		data  interface{}
+		data  *types.OffChainData
 		dbErr error
 		err   error
 	}{
 		{
 			name: "successfully got offchain data",
 			hash: types.ArgHash{},
-			data: types.ArgBytes("offchaindata"),
+			data: &types.OffChainData{
+				Key:      common.Hash{},
+				Value:    types.ArgBytes("offchaindata"),
+				BatchNum: 0,
+			},
 		},
 		{
-			name:  "db returns error",
-			hash:  types.ArgHash{},
-			data:  types.ArgBytes("offchaindata"),
+			name: "db returns error",
+			hash: types.ArgHash{},
+			data: &types.OffChainData{
+				Key:      common.Hash{},
+				Value:    types.ArgBytes("offchaindata"),
+				BatchNum: 0,
+			},
 			dbErr: errors.New("test error"),
 			err:   errors.New("failed to get the requested data"),
 		},
@@ -53,7 +61,7 @@ func TestEndpoints_GetOffChainData(t *testing.T) {
 				require.EqualError(t, tt.err, err.Error())
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.data, got)
+				require.Equal(t, types.ArgBytes(tt.data.Value), got)
 			}
 		})
 	}
@@ -63,23 +71,27 @@ func TestSyncEndpoints_ListOffChainData(t *testing.T) {
 	tests := []struct {
 		name   string
 		hashes []types.ArgHash
-		data   interface{}
+		data   []types.OffChainData
 		dbErr  error
 		err    error
 	}{
 		{
 			name:   "successfully got offchain data",
 			hashes: []types.ArgHash{},
-			data: map[common.Hash]types.ArgBytes{
-				common.BytesToHash(nil): types.ArgBytes("offchaindata"),
-			},
+			data: []types.OffChainData{{
+				Key:      common.BytesToHash(nil),
+				Value:    types.ArgBytes("offchaindata"),
+				BatchNum: 0,
+			}},
 		},
 		{
 			name:   "db returns error",
 			hashes: []types.ArgHash{},
-			data: map[common.Hash]types.ArgBytes{
-				common.BytesToHash(nil): types.ArgBytes("offchaindata"),
-			},
+			data: []types.OffChainData{{
+				Key:      common.BytesToHash(nil),
+				Value:    types.ArgBytes("offchaindata"),
+				BatchNum: 0,
+			}},
 			dbErr: errors.New("test error"),
 			err:   errors.New("failed to list the requested data"),
 		},
@@ -110,7 +122,13 @@ func TestSyncEndpoints_ListOffChainData(t *testing.T) {
 				require.EqualError(t, tt.err, err.Error())
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.data, got)
+
+				listMap := make(map[common.Hash]types.ArgBytes)
+				for _, data := range tt.data {
+					listMap[data.Key] = data.Value
+				}
+
+				require.Equal(t, listMap, got)
 			}
 		})
 	}

--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -26,7 +26,7 @@ const defaultBlockBatchSize = 32
 
 // SequencerTracker is an interface that defines functions that a sequencer tracker must implement
 type SequencerTracker interface {
-	GetSequenceBatch(batchNum uint64) (*sequencer.SeqBatch, error)
+	GetSequenceBatch(ctx context.Context, batchNum uint64) (*sequencer.SeqBatch, error)
 }
 
 // BatchSynchronizer watches for number events, checks if they are "locally" stored, then retrieves and stores missing data
@@ -95,9 +95,10 @@ func (bs *BatchSynchronizer) resolveCommittee() error {
 // Start starts the synchronizer
 func (bs *BatchSynchronizer) Start(ctx context.Context) {
 	log.Infof("starting batch synchronizer, DAC addr: %v", bs.self)
-	go bs.startUnresolvedBatchesProcessor(ctx)
+	go bs.processUnresolvedBatches(ctx)
 	go bs.produceEvents(ctx)
 	go bs.handleReorgs(ctx)
+	go bs.verifyBatches(ctx)
 }
 
 // Stop stops the synchronizer
@@ -112,7 +113,7 @@ func (bs *BatchSynchronizer) handleReorgs(ctx context.Context) {
 		case r := <-bs.reorgs:
 			bs.syncLock.Lock()
 
-			latest, err := getStartBlock(ctx, bs.db)
+			latest, err := getStartBlock(ctx, bs.db, L1SyncTask)
 			if err != nil {
 				log.Errorf("could not determine latest processed block: %v", err)
 				bs.syncLock.Unlock()
@@ -126,7 +127,7 @@ func (bs *BatchSynchronizer) handleReorgs(ctx context.Context) {
 				continue
 			}
 
-			if err = setStartBlock(ctx, bs.db, r.Number); err != nil {
+			if err = setStartBlock(ctx, bs.db, r.Number, L1SyncTask); err != nil {
 				log.Errorf("failed to store new start block to %d: %v", r.Number, err)
 			}
 
@@ -157,7 +158,7 @@ func (bs *BatchSynchronizer) filterEvents(ctx context.Context) error {
 	bs.syncLock.Lock()
 	defer bs.syncLock.Unlock()
 
-	start, err := getStartBlock(ctx, bs.db)
+	start, err := getStartBlock(ctx, bs.db, L1SyncTask)
 	if err != nil {
 		return err
 	}
@@ -210,11 +211,11 @@ func (bs *BatchSynchronizer) filterEvents(ctx context.Context) error {
 	for _, event := range events {
 		if err = bs.handleEvent(ctx, event); err != nil {
 			log.Errorf("failed to handle event: %v", err)
-			return setStartBlock(ctx, bs.db, event.Raw.BlockNumber-1)
+			return setStartBlock(ctx, bs.db, event.Raw.BlockNumber-1, L1SyncTask)
 		}
 	}
 
-	return setStartBlock(ctx, bs.db, end)
+	return setStartBlock(ctx, bs.db, end, L1SyncTask)
 }
 
 func (bs *BatchSynchronizer) handleEvent(parentCtx context.Context, event *polygonvalidium.PolygonvalidiumSequenceBatches) error {
@@ -245,7 +246,7 @@ func (bs *BatchSynchronizer) handleEvent(parentCtx context.Context, event *polyg
 	return storeUnresolvedBatchKeys(ctx, bs.db, batchKeys)
 }
 
-func (bs *BatchSynchronizer) startUnresolvedBatchesProcessor(ctx context.Context) {
+func (bs *BatchSynchronizer) processUnresolvedBatches(ctx context.Context) {
 	log.Info("starting handling unresolved batches")
 	for {
 		delay := time.NewTimer(bs.retry)
@@ -280,7 +281,7 @@ func (bs *BatchSynchronizer) handleUnresolvedBatches(ctx context.Context) error 
 			resolved = append(resolved, key)
 		} else {
 			var value *types.OffChainData
-			if value, err = bs.resolve(key); err != nil {
+			if value, err = bs.resolve(ctx, key); err != nil {
 				log.Errorf("failed to resolve batch %s: %v", key.Hash.Hex(), err)
 				continue
 			}
@@ -307,9 +308,9 @@ func (bs *BatchSynchronizer) handleUnresolvedBatches(ctx context.Context) error 
 	return nil
 }
 
-func (bs *BatchSynchronizer) resolve(batch types.BatchKey) (*types.OffChainData, error) {
+func (bs *BatchSynchronizer) resolve(ctx context.Context, batch types.BatchKey) (*types.OffChainData, error) {
 	// First try to get the data from the trusted sequencer
-	data := bs.trySequencer(batch)
+	data := bs.trySequencer(ctx, batch)
 	if data != nil {
 		return data, nil
 	}
@@ -318,8 +319,7 @@ func (bs *BatchSynchronizer) resolve(batch types.BatchKey) (*types.OffChainData,
 	if bs.committee.Length() == 0 {
 		// committee is resolved again once all members are evicted. They can be evicted
 		// for not having data, or their config being malformed
-		err := bs.resolveCommittee()
-		if err != nil {
+		if err := bs.resolveCommittee(); err != nil {
 			return nil, err
 		}
 	}
@@ -330,11 +330,14 @@ func (bs *BatchSynchronizer) resolve(batch types.BatchKey) (*types.OffChainData,
 	// iterate through them randomly until data is resolved
 	for _, r := range rand.Perm(len(members)) {
 		member := members[r]
-		if member.URL == "" || member.Addr == common.HexToAddress("0x0") || member.Addr == bs.self {
+		if member.URL == "" ||
+			common.HexToAddress("0x0").Cmp(member.Addr) == 0 ||
+			member.Addr.Cmp(bs.self) == 0 {
 			bs.committee.Delete(member.Addr)
 			continue // malformed committee, skip what is known to be wrong
 		}
-		value, err := bs.resolveWithMember(batch.Hash, member)
+
+		value, err := bs.resolveWithMember(ctx, batch, member)
 		if err != nil {
 			log.Warnf("error resolving, continuing: %v", err)
 			bs.committee.Delete(member.Addr)
@@ -343,12 +346,13 @@ func (bs *BatchSynchronizer) resolve(batch types.BatchKey) (*types.OffChainData,
 
 		return value, nil
 	}
+
 	return nil, rpc.NewRPCError(rpc.NotFoundErrorCode, "no data found for number %d, key %v", batch.Number, batch.Hash.Hex())
 }
 
 // trySequencer returns L2Data from the trusted sequencer, but does not return errors, only logs warnings if not found.
-func (bs *BatchSynchronizer) trySequencer(batch types.BatchKey) *types.OffChainData {
-	seqBatch, err := bs.sequencer.GetSequenceBatch(batch.Number)
+func (bs *BatchSynchronizer) trySequencer(ctx context.Context, batch types.BatchKey) *types.OffChainData {
+	seqBatch, err := bs.sequencer.GetSequenceBatch(ctx, batch.Number)
 	if err != nil {
 		log.Warnf("failed to get data from sequencer: %v", err)
 		return nil
@@ -359,29 +363,62 @@ func (bs *BatchSynchronizer) trySequencer(batch types.BatchKey) *types.OffChainD
 		log.Warnf("number %d: sequencer gave wrong data for key: %s", batch.Number, batch.Hash.Hex())
 		return nil
 	}
+
 	return &types.OffChainData{
-		Key:   batch.Hash,
-		Value: seqBatch.BatchL2Data,
+		Key:      batch.Hash,
+		Value:    seqBatch.BatchL2Data,
+		BatchNum: batch.Number,
 	}
 }
 
-func (bs *BatchSynchronizer) resolveWithMember(key common.Hash, member etherman.DataCommitteeMember) (*types.OffChainData, error) {
+func (bs *BatchSynchronizer) resolveWithMember(
+	parentCtx context.Context,
+	batch types.BatchKey,
+	member etherman.DataCommitteeMember,
+) (*types.OffChainData, error) {
 	cm := bs.rpcClientFactory.New(member.URL)
-	ctx, cancel := context.WithTimeout(context.Background(), bs.rpcTimeout)
+
+	ctx, cancel := context.WithTimeout(parentCtx, bs.rpcTimeout)
 	defer cancel()
 
-	log.Debugf("trying member %v at %v for key %v", member.Addr.Hex(), member.URL, key.Hex())
+	log.Debugf("trying member %v at %v for key %v", member.Addr.Hex(), member.URL, batch.Hash.Hex())
 
-	bytes, err := cm.GetOffChainData(ctx, key)
+	bytes, err := cm.GetOffChainData(ctx, batch.Hash)
 	if err != nil {
 		return nil, err
 	}
+
 	expectKey := crypto.Keccak256Hash(bytes)
-	if key != expectKey {
+	if batch.Hash.Cmp(expectKey) != 0 {
 		return nil, fmt.Errorf("unexpected key gotten from member: %v. Key: %v", member.Addr.Hex(), expectKey.Hex())
 	}
+
 	return &types.OffChainData{
-		Key:   key,
-		Value: bytes,
+		Key:      batch.Hash,
+		Value:    bytes,
+		BatchNum: batch.Number,
 	}, nil
+}
+
+func (bs *BatchSynchronizer) verifyBatches(ctx context.Context) {
+	log.Info("starting batch verifier")
+	for {
+		delay := time.NewTimer(bs.retry)
+		select {
+		case <-delay.C:
+			if err := bs.verifyUnverifiedBatches(ctx); err != nil {
+				log.Error(err)
+			}
+		case <-bs.stop:
+			return
+		}
+	}
+}
+
+// verifyUnverifiedBatches verifies unverified batches from the database.
+// It retrieves the data from the offchain data table and verifies the hash where the batch number is zero.
+// It loads the batch number from the blockchain.
+func (bs *BatchSynchronizer) verifyUnverifiedBatches(ctx context.Context) error {
+	// TODO: Implement
+	return nil
 }

--- a/synchronizer/batches_test.go
+++ b/synchronizer/batches_test.go
@@ -133,7 +133,7 @@ func TestBatchSynchronizer_Resolve(t *testing.T) {
 			committee:        NewCommitteeMapSafe(),
 		}
 
-		offChainData, err := batchSyncronizer.resolve(batchKey)
+		offChainData, err := batchSyncronizer.resolve(context.Background(), batchKey)
 		if config.isErrorExpected {
 			if config.errorString != "" {
 				require.ErrorContains(t, err, config.errorString)
@@ -156,7 +156,7 @@ func TestBatchSynchronizer_Resolve(t *testing.T) {
 		t.Parallel()
 
 		testFn(testConfig{
-			getSequenceBatchArgs: []interface{}{batchKey.Number},
+			getSequenceBatchArgs: []interface{}{context.Background(), batchKey.Number},
 			getSequenceBatchReturns: []interface{}{&sequencer.SeqBatch{
 				Number:      types.ArgUint64(batchKey.Number),
 				BatchL2Data: types.ArgBytes(data),
@@ -184,7 +184,7 @@ func TestBatchSynchronizer_Resolve(t *testing.T) {
 			isErrorExpected:                false,
 			getOffChainDataArgs:            [][]interface{}{{mock.Anything, batchKey.Hash}},
 			getOffChainDataReturns:         [][]interface{}{{data, nil}},
-			getSequenceBatchArgs:           []interface{}{batchKey.Number},
+			getSequenceBatchArgs:           []interface{}{context.Background(), batchKey.Number},
 			getSequenceBatchReturns:        []interface{}{nil, errors.New("error")},
 			getCurrentDataCommitteeReturns: []interface{}{committee, nil},
 			newArgs:                        [][]interface{}{{committee.Members[0].URL}},
@@ -208,7 +208,7 @@ func TestBatchSynchronizer_Resolve(t *testing.T) {
 		}
 
 		testFn(testConfig{
-			getSequenceBatchArgs:           []interface{}{batchKey.Number},
+			getSequenceBatchArgs:           []interface{}{context.Background(), batchKey.Number},
 			getSequenceBatchReturns:        []interface{}{nil, errors.New("error")},
 			getCurrentDataCommitteeReturns: []interface{}{committee, nil},
 			newArgs: [][]interface{}{
@@ -257,7 +257,7 @@ func TestBatchSynchronizer_Resolve(t *testing.T) {
 				{[]byte{0, 0, 0, 1}, nil}, // member doesn't have batch
 				{[]byte{0, 0, 0, 1}, nil}, // member doesn't have batch
 			},
-			getSequenceBatchArgs:           []interface{}{batchKey.Number},
+			getSequenceBatchArgs:           []interface{}{context.Background(), batchKey.Number},
 			getSequenceBatchReturns:        []interface{}{nil, errors.New("error")},
 			getCurrentDataCommitteeReturns: []interface{}{committee, nil},
 		})
@@ -596,7 +596,7 @@ func TestBatchSynchronizer_HandleUnresolvedBatches(t *testing.T) {
 				mock.Anything,
 			},
 			deleteUnresolvedBatchKeysReturns: []interface{}{nil},
-			getSequenceBatchArgs:             []interface{}{uint64(10)},
+			getSequenceBatchArgs:             []interface{}{context.Background(), uint64(10)},
 			getSequenceBatchReturns: []interface{}{&sequencer.SeqBatch{
 				Number:      types.ArgUint64(10),
 				BatchL2Data: types.ArgBytes(batchL2Data),

--- a/synchronizer/batches_test.go
+++ b/synchronizer/batches_test.go
@@ -732,9 +732,9 @@ func TestBatchSyncronizer_HandleReorgs(t *testing.T) {
 	testFn := func(config testConfig) {
 		dbMock := mocks.NewDB(t)
 
-		dbMock.On("GetLastProcessedBlock", mock.Anything, L1SyncTask).Return(config.getLastProcessedBlockReturns...).Once()
+		dbMock.On("GetLastProcessedBlock", mock.Anything, string(L1SyncTask)).Return(config.getLastProcessedBlockReturns...).Once()
 		if config.storeLastProcessedBlockReturns != nil {
-			dbMock.On("StoreLastProcessedBlock", mock.Anything, mock.Anything, L1SyncTask).
+			dbMock.On("StoreLastProcessedBlock", mock.Anything, mock.Anything, string(L1SyncTask)).
 				Return(config.storeLastProcessedBlockReturns...).Once()
 		}
 

--- a/synchronizer/batches_test.go
+++ b/synchronizer/batches_test.go
@@ -734,7 +734,7 @@ func TestBatchSyncronizer_HandleReorgs(t *testing.T) {
 
 		dbMock.On("GetLastProcessedBlock", mock.Anything, L1SyncTask).Return(config.getLastProcessedBlockReturns...).Once()
 		if config.storeLastProcessedBlockReturns != nil {
-			dbMock.On("StoreLastProcessedBlock", mock.Anything, L1SyncTask, mock.Anything).
+			dbMock.On("StoreLastProcessedBlock", mock.Anything, mock.Anything, L1SyncTask).
 				Return(config.storeLastProcessedBlockReturns...).Once()
 		}
 

--- a/synchronizer/init.go
+++ b/synchronizer/init.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/0xPolygon/cdk-data-availability/db"
 	"github.com/0xPolygon/cdk-data-availability/etherman"
 	"github.com/0xPolygon/cdk-data-availability/log"
@@ -22,27 +24,62 @@ func InitStartBlock(parentCtx context.Context, db db.DB, em etherman.Etherman, g
 	ctx, cancel := context.WithTimeout(parentCtx, initBlockTimeout)
 	defer cancel()
 
-	current, err := getStartBlock(ctx, db)
+	// Get start block either from genesis block or from contract deployment block number
+	startBlock, err := getInitialStartBlock(ctx, em, genesisBlock, validiumAddr)
 	if err != nil {
 		return err
 	}
-	if current > 0 {
-		// no need to resolve start block, it's already been set
-		return nil
-	}
-	log.Info("starting search for start block of contract ", validiumAddr)
 
+	initializeBlock := func(syncTask SyncTask) error {
+		current, err := getStartBlock(ctx, db, syncTask)
+		if err != nil {
+			return err
+		}
+
+		if current > 0 {
+			// no need to resolve start block, it's already been set
+			return nil
+		}
+
+		return setStartBlock(ctx, db, startBlock.Uint64(), syncTask)
+	}
+
+	var errGroup errgroup.Group
+
+	// Init start block for L1SyncTask
+	errGroup.Go(func() error {
+		log.Info("initializing start block for L1 sync task")
+
+		return initializeBlock(L1SyncTask)
+	})
+
+	// Init start block for L1BatchNumTask
+	errGroup.Go(func() error {
+		log.Info("initializing start block for L1_BATCH_NUM sync task")
+
+		return initializeBlock(L1BatchNumTask)
+	})
+
+	return errGroup.Wait()
+}
+
+func getInitialStartBlock(
+	ctx context.Context,
+	em etherman.Etherman,
+	genesisBlock uint64,
+	validiumAddr common.Address,
+) (*big.Int, error) {
 	startBlock := new(big.Int)
 	if genesisBlock != 0 {
 		startBlock.SetUint64(genesisBlock)
 	} else {
-		startBlock, err = findContractDeploymentBlock(ctx, em, validiumAddr)
-		if err != nil {
-			return err
+		var err error
+		if startBlock, err = findContractDeploymentBlock(ctx, em, validiumAddr); err != nil {
+			return nil, err
 		}
 	}
 
-	return setStartBlock(ctx, db, startBlock.Uint64())
+	return startBlock, nil
 }
 
 func findContractDeploymentBlock(ctx context.Context, em etherman.Etherman, contract common.Address) (*big.Int, error) {

--- a/synchronizer/init_test.go
+++ b/synchronizer/init_test.go
@@ -90,7 +90,7 @@ func Test_InitStartBlock(t *testing.T) {
 		t.Parallel()
 
 		testFn(t, testConfig{
-			getLastProcessedBlockArgs:    []interface{}{mock.Anything, L1SyncTask},
+			getLastProcessedBlockArgs:    []interface{}{mock.Anything, string(L1SyncTask)},
 			getLastProcessedBlockReturns: []interface{}{uint64(1), errors.New("can't get last processed block")},
 			isErrorExpected:              true,
 		})
@@ -100,7 +100,7 @@ func Test_InitStartBlock(t *testing.T) {
 		t.Parallel()
 
 		testFn(t, testConfig{
-			getLastProcessedBlockArgs:    []interface{}{mock.Anything, L1SyncTask},
+			getLastProcessedBlockArgs:    []interface{}{mock.Anything, string(L1SyncTask)},
 			getLastProcessedBlockReturns: []interface{}{uint64(10), nil},
 			isErrorExpected:              false,
 		})
@@ -110,7 +110,7 @@ func Test_InitStartBlock(t *testing.T) {
 		t.Parallel()
 
 		testFn(t, testConfig{
-			getLastProcessedBlockArgs:    []interface{}{mock.Anything, L1SyncTask},
+			getLastProcessedBlockArgs:    []interface{}{mock.Anything, string(L1SyncTask)},
 			getLastProcessedBlockReturns: []interface{}{uint64(0), nil},
 			headerByNumberArgs:           []interface{}{mock.Anything, mock.Anything},
 			headerByNumberReturns:        []interface{}{nil, errors.New("error")},
@@ -122,9 +122,9 @@ func Test_InitStartBlock(t *testing.T) {
 		t.Parallel()
 
 		testFn(t, testConfig{
-			getLastProcessedBlockArgs:      []interface{}{mock.Anything, L1SyncTask},
+			getLastProcessedBlockArgs:      []interface{}{mock.Anything, string(L1SyncTask)},
 			getLastProcessedBlockReturns:   []interface{}{uint64(0), nil},
-			storeLastProcessedBlockArgs:    []interface{}{mock.Anything, L1SyncTask, uint64(0), mock.Anything},
+			storeLastProcessedBlockArgs:    []interface{}{mock.Anything, uint64(0), string(L1SyncTask)},
 			storeLastProcessedBlockReturns: []interface{}{errors.New("error")},
 			headerByNumberArgs:             []interface{}{mock.Anything, mock.Anything},
 			headerByNumberReturns: []interface{}{ethTypes.NewBlockWithHeader(&ethTypes.Header{
@@ -138,9 +138,9 @@ func Test_InitStartBlock(t *testing.T) {
 		t.Parallel()
 
 		testFn(t, testConfig{
-			getLastProcessedBlockArgs:      []interface{}{mock.Anything, L1SyncTask},
+			getLastProcessedBlockArgs:      []interface{}{mock.Anything, string(L1SyncTask)},
 			getLastProcessedBlockReturns:   []interface{}{uint64(0), nil},
-			storeLastProcessedBlockArgs:    []interface{}{mock.Anything, L1SyncTask, uint64(2), mock.Anything},
+			storeLastProcessedBlockArgs:    []interface{}{mock.Anything, uint64(2), string(L1SyncTask)},
 			storeLastProcessedBlockReturns: []interface{}{nil},
 			headerByNumberArgs:             []interface{}{mock.Anything, mock.Anything},
 			headerByNumberReturns: []interface{}{ethTypes.NewBlockWithHeader(&ethTypes.Header{

--- a/synchronizer/store.go
+++ b/synchronizer/store.go
@@ -17,11 +17,6 @@ const (
 	// L1SyncTask is the name of the L1 sync task
 	L1SyncTask SyncTask = "L1"
 
-	// L1BatchNumTask is the name of the L1 batch number task.
-	// The task identifies the last block number processed by the logic that populates
-	// batch numbers for the offchain data.
-	L1BatchNumTask SyncTask = "L1_BATCH_NUM"
-
 	dbTimeout = 2 * time.Second
 )
 
@@ -48,11 +43,11 @@ func setStartBlock(parentCtx context.Context, db dbTypes.DB, block uint64, syncT
 	return db.StoreLastProcessedBlock(ctx, block, string(syncTask))
 }
 
-func exists(parentCtx context.Context, db dbTypes.DB, key common.Hash) bool {
+func listOffchainData(parentCtx context.Context, db dbTypes.DB, keys []common.Hash) ([]types.OffChainData, error) {
 	ctx, cancel := context.WithTimeout(parentCtx, dbTimeout)
 	defer cancel()
 
-	return db.Exists(ctx, key)
+	return db.ListOffChainData(ctx, keys)
 }
 
 func storeUnresolvedBatchKeys(parentCtx context.Context, db dbTypes.DB, keys []types.BatchKey) error {

--- a/synchronizer/store_test.go
+++ b/synchronizer/store_test.go
@@ -51,7 +51,7 @@ func Test_getStartBlock(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testDB := tt.db(t)
 
-			if block, err := getStartBlock(context.Background(), testDB); tt.wantErr {
+			if block, err := getStartBlock(context.Background(), testDB, l1SyncTask); tt.wantErr {
 				require.ErrorIs(t, err, testError)
 			} else {
 				require.NoError(t, err)
@@ -100,7 +100,7 @@ func Test_setStartBlock(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testDB := tt.db(t)
 
-			if err := setStartBlock(context.Background(), testDB, tt.block); tt.wantErr {
+			if err := setStartBlock(context.Background(), testDB, tt.block, l1SyncTask); tt.wantErr {
 				require.ErrorIs(t, err, testError)
 			} else {
 				require.NoError(t, err)

--- a/synchronizer/store_test.go
+++ b/synchronizer/store_test.go
@@ -75,7 +75,7 @@ func Test_setStartBlock(t *testing.T) {
 			db: func(t *testing.T) db.DB {
 				mockDB := mocks.NewDB(t)
 
-				mockDB.On("StoreLastProcessedBlock", mock.Anything, "L1", uint64(2)).
+				mockDB.On("StoreLastProcessedBlock", mock.Anything, uint64(2), "L1").
 					Return(testError)
 
 				return mockDB
@@ -88,7 +88,7 @@ func Test_setStartBlock(t *testing.T) {
 			db: func(t *testing.T) db.DB {
 				mockDB := mocks.NewDB(t)
 
-				mockDB.On("StoreLastProcessedBlock", mock.Anything, "L1", uint64(4)).
+				mockDB.On("StoreLastProcessedBlock", mock.Anything, uint64(4), "L1").
 					Return(nil)
 
 				return mockDB
@@ -105,50 +105,6 @@ func Test_setStartBlock(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-		})
-	}
-}
-
-func Test_exists(t *testing.T) {
-	tests := []struct {
-		name string
-		db   func(t *testing.T) db.DB
-		key  common.Hash
-		want bool
-	}{
-		{
-			name: "Exists returns true",
-			db: func(t *testing.T) db.DB {
-				mockDB := mocks.NewDB(t)
-
-				mockDB.On("Exists", mock.Anything, common.HexToHash("0x01")).
-					Return(true)
-
-				return mockDB
-			},
-			key:  common.HexToHash("0x01"),
-			want: true,
-		},
-		{
-			name: "Exists returns false",
-			db: func(t *testing.T) db.DB {
-				mockDB := mocks.NewDB(t)
-
-				mockDB.On("Exists", mock.Anything, common.HexToHash("0x02")).
-					Return(false)
-
-				return mockDB
-			},
-			key:  common.HexToHash("0x02"),
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			testDB := tt.db(t)
-
-			got := exists(context.Background(), testDB, tt.key)
-			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/synchronizer/store_test.go
+++ b/synchronizer/store_test.go
@@ -51,7 +51,7 @@ func Test_getStartBlock(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testDB := tt.db(t)
 
-			if block, err := getStartBlock(context.Background(), testDB, l1SyncTask); tt.wantErr {
+			if block, err := getStartBlock(context.Background(), testDB, L1SyncTask); tt.wantErr {
 				require.ErrorIs(t, err, testError)
 			} else {
 				require.NoError(t, err)
@@ -100,7 +100,7 @@ func Test_setStartBlock(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testDB := tt.db(t)
 
-			if err := setStartBlock(context.Background(), testDB, tt.block, l1SyncTask); tt.wantErr {
+			if err := setStartBlock(context.Background(), testDB, tt.block, L1SyncTask); tt.wantErr {
 				require.ErrorIs(t, err, testError)
 			} else {
 				require.NoError(t, err)

--- a/types/types.go
+++ b/types/types.go
@@ -31,8 +31,9 @@ type BatchKey struct {
 
 // OffChainData represents some data that is not stored on chain and should be preserved
 type OffChainData struct {
-	Key   common.Hash
-	Value []byte
+	Key      common.Hash
+	Value    []byte
+	BatchNum uint64
 }
 
 // ArgUint64 helps to marshal uint64 values provided in the RPC requests


### PR DESCRIPTION
- Added migration for adding `batch_num` column to `offchain_data` table.
  - The migration resets the last block number for L1 task in order to trigger resync process that will updated batch number in all existing records. 
- Updated DB layer logic to handle a new field. 
- Updated `handleUnresolvedBatches` function to populate a batch number field 
  - It also populates a batch number field for existing records. This is needed to updated batch number in all existing records.

