### PR TITLE
add Set and Get for Signature of types SignedSequence

### DIFF
--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -11,4 +11,6 @@ type SignedSequenceInterface interface {
 	Signer() (common.Address, error)
 	OffChainData() []OffChainData
 	Sign(privateKey *ecdsa.PrivateKey) (ArgBytes, error)
+	SetSignature([]byte)
+	GetSignature() []byte
 }

--- a/types/sequence.go
+++ b/types/sequence.go
@@ -84,3 +84,13 @@ func (s *SignedSequence) OffChainData() []OffChainData {
 func (s *SignedSequence) Sign(privateKey *ecdsa.PrivateKey) (ArgBytes, error) {
 	return s.Sequence.Sign(privateKey)
 }
+
+// SetSignature set signature
+func (s *SignedSequence) SetSignature(sign []byte) {
+	s.Signature = sign
+}
+
+// GetSignature returns signature
+func (s *SignedSequence) GetSignature() []byte {
+	return s.Signature
+}

--- a/types/sequence_test.go
+++ b/types/sequence_test.go
@@ -56,3 +56,10 @@ func TestSigning(t *testing.T) {
 		}
 	}
 }
+
+func TestGetSetSignature(t *testing.T) {
+	sut := SignedSequence{}
+	signature := []byte{1, 2, 3}
+	sut.SetSignature(signature)
+	assert.Equal(t, signature, sut.GetSignature())
+}

--- a/types/sequencebanana.go
+++ b/types/sequencebanana.go
@@ -114,3 +114,13 @@ func (s *SignedSequenceBanana) OffChainData() []OffChainData {
 func (s *SignedSequenceBanana) Sign(privateKey *ecdsa.PrivateKey) (ArgBytes, error) {
 	return s.Sequence.Sign(privateKey)
 }
+
+// SetSignature set signature
+func (s *SignedSequenceBanana) SetSignature(sign []byte) {
+	s.Signature = sign
+}
+
+// GetSignature returns signature
+func (s *SignedSequenceBanana) GetSignature() []byte {
+	return s.Signature
+}

--- a/types/sequencebanana_test.go
+++ b/types/sequencebanana_test.go
@@ -1,0 +1,14 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSetSignatureBanana(t *testing.T) {
+	sut := SignedSequenceBanana{}
+	signature := []byte{1, 2, 3}
+	sut.SetSignature(signature)
+	assert.Equal(t, signature, sut.GetSignature())
+}


### PR DESCRIPTION
Closes #107 

Add next method to interface `SignedSequenceInterface`:
```
	SetSignature([]byte)
	GetSignature() []byte
```