### PR TITLE
Removed signature normalisation

### DIFF
--- a/types/sign.go
+++ b/types/sign.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	// ErrNonCanonicalSignature is returned when the signature is not canonical.
-	ErrNonCanonicalSignature = errors.New("received non-custodial signature")
+	ErrNonCanonicalSignature = errors.New("received non-canonical signature")
 )
 
 // Sign the hashToSIgn with the given privateKey.


### PR DESCRIPTION
The signature is already normalized: https://github.com/ethereum/go-ethereum/blob/master/crypto/secp256k1/libsecp256k1/include/secp256k1.h#L439-L460