### PR TITLE
Add synchronization for banana sequences

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/0xPolygon/cdk-data-availability
 go 1.21.3
 
 require (
-	github.com/0xPolygon/cdk-contracts-tooling v0.0.0-20240426091844-5cd6921eed9f
+	github.com/0xPolygon/cdk-contracts-tooling v0.0.0-20240826154954-f6182d2b17a2
 	github.com/DATA-DOG/go-sqlmock v1.5.1
 	github.com/didip/tollbooth/v6 v6.1.2
 	github.com/ethereum/go-ethereum v1.13.14

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/0xPolygon/cdk-contracts-tooling v0.0.0-20240426091844-5cd6921eed9f h1:EiChBxSyJxMjgPdbYWujqD32r991Yhffrm78STAXB4k=
 github.com/0xPolygon/cdk-contracts-tooling v0.0.0-20240426091844-5cd6921eed9f/go.mod h1:mFlcEjsm2YBBsu8atHJ3zyVnwM+Z/fMXpVmIJge+WVU=
+github.com/0xPolygon/cdk-contracts-tooling v0.0.0-20240826154954-f6182d2b17a2 h1:N5qvWG4amhUt6d1F4Kf8AdJZs4z7/xZfE3v/Im2afNM=
+github.com/0xPolygon/cdk-contracts-tooling v0.0.0-20240826154954-f6182d2b17a2/go.mod h1:mFlcEjsm2YBBsu8atHJ3zyVnwM+Z/fMXpVmIJge+WVU=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/DATA-DOG/go-sqlmock v1.5.1 h1:FK6RCIUSfmbnI/imIICmboyQBkOckutaa6R5YYlLZyo=

--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -228,7 +228,7 @@ func (bs *BatchSynchronizer) filterEvents(ctx context.Context) error {
 	// Handle events
 	for _, event := range events {
 		if err = bs.handleEvent(ctx, event); err != nil {
-			log.Errorf("failed to handle event: %v", err)
+			log.Errorf("failed to handleEvent: %v", err)
 			return setStartBlock(ctx, bs.db, event.Raw.BlockNumber-1, L1SyncTask)
 		}
 	}

--- a/synchronizer/batches.go
+++ b/synchronizer/batches.go
@@ -258,7 +258,7 @@ func (bs *BatchSynchronizer) handleEvent(
 	var batchKeys []types.BatchKey
 	for i, j := 0, len(keys)-1; i < len(keys); i, j = i+1, j-1 {
 		batchKeys = append(batchKeys, types.BatchKey{
-			Number: event.NumBatch - uint64(i),
+			Number: event.NumBatch - uint64(i), //nolint:gosec
 			Hash:   keys[j],
 		})
 	}

--- a/synchronizer/util_test.go
+++ b/synchronizer/util_test.go
@@ -11,8 +11,10 @@ func Test_SequenceBatchesValidiumMethodIDs_Equality(t *testing.T) {
 	var (
 		expectedSequenceBatchesValidiumEtrog      = "2d72c248"
 		expectedSequenceBatchesValidiumElderberry = "db5b0ed7"
+		expectedSequenceBatchesValidiumBanana     = "165e8a8d"
 	)
 
 	require.Equal(t, expectedSequenceBatchesValidiumEtrog, hex.EncodeToString(methodIDSequenceBatchesValidiumEtrog))
 	require.Equal(t, expectedSequenceBatchesValidiumElderberry, hex.EncodeToString(methodIDSequenceBatchesValidiumElderberry))
+	require.Equal(t, expectedSequenceBatchesValidiumBanana, hex.EncodeToString(methodIDSequenceBatchesValidiumBanana))
 }


### PR DESCRIPTION
Add support to syncing senqueceBatchesValidium for Banana

Version `0.0.9` is reporting this error: 
```
2024-09-12T14:41:31.687Z ERROR synchronizer/batches.go:231 failed to handle event: unrecognized method id: 165e8a8d 

```