### PR TITLE
refactor: In functions like ListOffChainData and GetMissingBatchKeys, although defer rows.Close() is used, if QueryxContext fails, rows will be nil. Calling defer rows.Close() in this case can trigger a panic.

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -262,8 +262,9 @@ func (db *pgDB) ListOffChainData(ctx context.Context, keys []common.Hash) ([]typ
 	if err != nil {
 		return nil, err
 	}
-
-	defer rows.Close()
+	if rows != nil {
+		defer rows.Close()
+	}
 
 	type row struct {
 		Key   string `db:"key"`


### PR DESCRIPTION
In functions like ListOffChainData and GetMissingBatchKeys, although defer rows.Close() is used, if QueryxContext fails, rows will be nil. Calling defer rows.Close() in this case can trigger a panic.