### PR TITLE
Allow ssl mode to be configured

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Download code coverage results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage-report
 

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -57,7 +57,7 @@ jobs:
           name: code-coverage-report
 
       - name: Analyze with SonarCloud
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -35,7 +35,7 @@ jobs:
       working-directory: test
 
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: code-coverage-report
         path: test/coverage.out

--- a/config/default.go
+++ b/config/default.go
@@ -35,7 +35,7 @@ Host = "cdk-data-availability-db"
 Port = "5432"
 EnableLog = false
 MaxConns = 200
-SslMode = "disable"
+SSLMode = "disable"
 
 [RPC]
 Host = "0.0.0.0"

--- a/config/default.go
+++ b/config/default.go
@@ -35,6 +35,7 @@ Host = "cdk-data-availability-db"
 Port = "5432"
 EnableLog = false
 MaxConns = 200
+SslMode = "disable"
 
 [RPC]
 Host = "0.0.0.0"

--- a/db/config.go
+++ b/db/config.go
@@ -32,14 +32,14 @@ type Config struct {
 	// MaxConns is the maximum number of connections in the pool.
 	MaxConns int `mapstructure:"MaxConns"`
 
-	// SslMode: "require", "verify-full", "verify-ca", and "disable"
-	SslMode string `mapstructure:"SslMode"`
+	// SSLMode: "require", "verify-full", "verify-ca", and "disable"
+	SSLMode string `mapstructure:"SSLMode"`
 }
 
 // InitContext initializes DB connection by the given config
 func InitContext(ctx context.Context, cfg Config) (*sqlx.DB, error) {
 	psqlInfo := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
-		cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.Name, cfg.SslMode)
+		cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.Name, cfg.SSLMode)
 
 	conn, err := sqlx.ConnectContext(ctx, "postgres", psqlInfo)
 	if err != nil {

--- a/db/config.go
+++ b/db/config.go
@@ -31,12 +31,15 @@ type Config struct {
 
 	// MaxConns is the maximum number of connections in the pool.
 	MaxConns int `mapstructure:"MaxConns"`
+
+	// SslMode: "require", "verify-full", "verify-ca", and "disable"
+	SslMode string `mapstructure:"SslMode"`
 }
 
 // InitContext initializes DB connection by the given config
 func InitContext(ctx context.Context, cfg Config) (*sqlx.DB, error) {
-	psqlInfo := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
-		cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.Name)
+	psqlInfo := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.Name, cfg.SslMode)
 
 	conn, err := sqlx.ConnectContext(ctx, "postgres", psqlInfo)
 	if err != nil {


### PR DESCRIPTION
This PR adds `SSLMode` configuration. It can be set to "require", "verify-full", "verify-ca", and "disable" with "disable" as default (the current behavior).

The request was to remove the sslmode parameter, where the underlying connection defaults to "require" as default. However, this PR is less intrusive to other deployment upgrades that do not require it currently.

The requester should add `SSLMode` = "require" (or whatever is needed) to the DB section of configuration file.